### PR TITLE
Channel per consumer

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,5 @@
 use Mix.Config
 
 config :railway_ipc,
-       stream_adapter: RailwayIpc.StreamMock,
-       payload_converter: RailwayIpc.PayloadMock
+  stream_adapter: RailwayIpc.StreamMock,
+  payload_converter: RailwayIpc.PayloadMock

--- a/lib/railway_ipc/application.ex
+++ b/lib/railway_ipc/application.ex
@@ -1,14 +1,10 @@
 defmodule RailwayIpc.Application do
-  # See https://hexdocs.pm/elixir/Application.html
-  # for more information on OTP Applications
   @moduledoc false
 
   use Application
 
   def start(_type, _args) do
-    children = [
-      {RailwayIpc.Connection, [name: RailwayIpc.Connection]}
-    ]
+    children = []
 
     opts = [strategy: :one_for_one, name: RailwayIpc.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/railway_ipc/connection.ex
+++ b/lib/railway_ipc/connection.ex
@@ -56,18 +56,13 @@ defmodule RailwayIpc.Connection do
           connection: connection
         }
       ) do
-    try do
-      with {:ok, channels, channel} <-
-             @stream_adapter.get_channel_from_cache(connection, channels, spec.consumer_module),
-           :ok <- @stream_adapter.bind_queue(channel, spec) do
-        {:reply, {:ok, channel}, %{state | consumer_channels: channels}}
-      else
-        {:error, error} ->
-          {:reply, {:error, error}, state}
-      end
-    rescue
-      e ->
-        IO.inspect(e)
+    with {:ok, channels, channel} <-
+           @stream_adapter.get_channel_from_cache(connection, channels, spec.consumer_module),
+         :ok <- @stream_adapter.bind_queue(channel, spec) do
+      {:reply, {:ok, channel}, %{state | consumer_channels: channels}}
+    else
+      {:error, error} ->
+        {:reply, {:error, error}, state}
     end
   end
 

--- a/lib/railway_ipc/payload_behaviour.ex
+++ b/lib/railway_ipc/payload_behaviour.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.PayloadBehaviour do
   @callback decode(payload :: any()) :: {:ok, message :: map()} | {:error, error :: binary()}
-  @callback encode(protobuf_struct :: map()) :: {:ok, message :: binary()} | {:error, error :: binary()}
+  @callback encode(protobuf_struct :: map()) ::
+              {:ok, message :: binary()} | {:error, error :: binary()}
 end

--- a/lib/railway_ipc/publisher.ex
+++ b/lib/railway_ipc/publisher.ex
@@ -1,13 +1,22 @@
 defmodule RailwayIpc.Publisher do
   defmacro __using__(opts) do
     quote do
-      @stream_adapter Application.get_env(:railway_ipc, :stream_adapter, RailwayIpc.RabbitMQ.RabbitMQAdapter)
-      @payload_converter Application.get_env(:railway_ipc, :payload_converter, RailwayIpc.RabbitMQ.Payload)
+      @stream_adapter Application.get_env(
+                        :railway_ipc,
+                        :stream_adapter,
+                        RailwayIpc.RabbitMQ.RabbitMQAdapter
+                      )
+      @payload_converter Application.get_env(
+                           :railway_ipc,
+                           :payload_converter,
+                           RailwayIpc.RabbitMQ.Payload
+                         )
 
       def publish(message) do
         {:ok, message} = @payload_converter.encode(message)
+
         @stream_adapter.publish(
-          RailwayIpc.Connection.channel(),
+          RailwayIpc.Connection.publisher_channel(),
           unquote(Keyword.get(opts, :exchange)),
           message
         )

--- a/lib/railway_ipc/rabbit_mq/payload.ex
+++ b/lib/railway_ipc/rabbit_mq/payload.ex
@@ -8,9 +8,9 @@ defmodule RailwayIpc.RabbitMQ.Payload do
 
   def decode(payload) do
     with {:decode_json, {:ok, %{"type" => type, "encoded_message" => encoded_message}}} <- {
-      :decode_json,
-      Jason.decode(payload)
-    },
+           :decode_json,
+           Jason.decode(payload)
+         },
          {:convert_module, module} <- {:convert_module, module_from_type(type)},
          {:check_module_exists, true} <- {:check_module_exists, module_defined?(module)},
          {:decode_message, message} <- {:decode_message, decode_message(module, encoded_message)} do
@@ -18,8 +18,10 @@ defmodule RailwayIpc.RabbitMQ.Payload do
     else
       {:decode_json, {:ok, _}} ->
         {:error, "Missing keys: #{payload}. Expecting type and encoded_message keys"}
+
       {:decode_json, {:error, _}} ->
         {:error, "Malformed JSON given: #{payload}"}
+
       {:check_module_exists, false} ->
         %{"type" => type} = Jason.decode!(payload)
         {:error, "Unknown message type #{type}"}
@@ -33,20 +35,23 @@ defmodule RailwayIpc.RabbitMQ.Payload do
         type: encode_type(protobuf_struct),
         encoded_message: encode_message(protobuf_struct)
       }
-      |> Jason.encode!
+      |> Jason.encode!()
     }
   end
 
   def encode_message(protobuf_struct) do
     protobuf_struct
     |> protobuf_struct.__struct__.encode
-    |> Base.encode64
+    |> Base.encode64()
   end
 
   def encode_type(protobuf_struct) do
     module = protobuf_struct.__struct__
-    module_name = module
-                  |> to_string
+
+    module_name =
+      module
+      |> to_string
+
     Regex.replace(~r/\AElixir\./, module_name, "")
     |> String.replace(".", "::")
   end
@@ -54,13 +59,12 @@ defmodule RailwayIpc.RabbitMQ.Payload do
   def module_from_type(type) do
     type
     |> String.split("::")
-    |> Module.concat
+    |> Module.concat()
   end
 
   def decode_message(module, encoded_message) do
     encoded_message
-    |> Base.decode64!
+    |> Base.decode64!()
     |> module.decode
   end
 end
-

--- a/lib/railway_ipc/stream_behaviour.ex
+++ b/lib/railway_ipc/stream_behaviour.ex
@@ -10,6 +10,12 @@ defmodule RailwayIpc.StreamBehaviour do
               }
             ) :: :ok | {:error, any()}
 
+  @callback get_channel_from_cache(
+              connection :: map(),
+              channels :: map(),
+              consumer_module :: module()
+            ) :: {:ok, channel_cache :: map(), channel :: map()}
+  @callback get_channel(connection :: map()) :: {:ok, channel :: map()} | {:error, any()}
   @callback ack(channel :: map(), deliver_tag :: binary()) :: any()
   @callback publish(channel :: map(), exchange :: binary(), message :: map()) :: any()
   @callback close_connection(connection :: map() | nil) :: any()

--- a/lib/railway_ipc/supervisor.ex
+++ b/lib/railway_ipc/supervisor.ex
@@ -1,12 +1,14 @@
 defmodule RailwayIpc.Connection.Supervisor do
   use Supervisor
 
-  def start_link(additional_children) do
+  def start_link(additional_children \\ []) do
     Supervisor.start_link(__MODULE__, additional_children, name: __MODULE__)
   end
 
   def init(additional_children) do
-    children = [RailwayIpc.Connection] ++ additional_children
+    children = [
+                 {RailwayIpc.Connection, name: RailwayIpc.Connection}
+               ] ++ additional_children
     Supervisor.init(children, strategy: :rest_for_one)
   end
 end

--- a/lib/railway_ipc/supervisor.ex
+++ b/lib/railway_ipc/supervisor.ex
@@ -10,9 +10,12 @@ defmodule RailwayIpc.Connection.Supervisor do
       {RailwayIpc.Connection, name: RailwayIpc.Connection},
       %{
         id: Supervisor,
-        start: {Supervisor, :start_link, [additional_children, [name: RailwayIpc.Consumers.Supervisor, strategy: :one_for_one]]}
+        start:
+          {Supervisor, :start_link,
+           [additional_children, [name: RailwayIpc.Consumer.Supervisor, strategy: :one_for_one]]}
       }
     ]
-    Supervisor.init(children, strategy: :one_for_all)
+
+    Supervisor.init(children, strategy: :rest_for_all)
   end
 end

--- a/lib/railway_ipc/supervisor.ex
+++ b/lib/railway_ipc/supervisor.ex
@@ -1,0 +1,12 @@
+defmodule RailwayIpc.Connection.Supervisor do
+  use Supervisor
+
+  def start_link(additional_children) do
+    Supervisor.start_link(__MODULE__, additional_children, name: __MODULE__)
+  end
+
+  def init(additional_children) do
+    children = [RailwayIpc.Connection] ++ additional_children
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+end

--- a/lib/railway_ipc/supervisor.ex
+++ b/lib/railway_ipc/supervisor.ex
@@ -7,8 +7,12 @@ defmodule RailwayIpc.Connection.Supervisor do
 
   def init(additional_children) do
     children = [
-                 {RailwayIpc.Connection, name: RailwayIpc.Connection}
-               ] ++ additional_children
+      {RailwayIpc.Connection, name: RailwayIpc.Connection},
+      %{
+        id: Supervisor,
+        start: {Supervisor, :start_link, [additional_children, [name: RailwayIpc.Consumers.Supervisor, strategy: :one_for_one]]}
+      }
+    ]
     Supervisor.init(children, strategy: :rest_for_one)
   end
 end

--- a/lib/railway_ipc/supervisor.ex
+++ b/lib/railway_ipc/supervisor.ex
@@ -13,6 +13,6 @@ defmodule RailwayIpc.Connection.Supervisor do
         start: {Supervisor, :start_link, [additional_children, [name: RailwayIpc.Consumers.Supervisor, strategy: :one_for_one]]}
       }
     ]
-    Supervisor.init(children, strategy: :rest_for_one)
+    Supervisor.init(children, strategy: :one_for_all)
   end
 end

--- a/test/railway_ipc/connection_test.exs
+++ b/test/railway_ipc/connection_test.exs
@@ -9,79 +9,101 @@ defmodule RailwayIpc.ConnectionTest do
 
   test "Connects to stream correctly" do
     channel = %{name: "some channel"}
+    connection = %{pid: self()}
+
     StreamMock
     |> expect(
-         :connect,
-         fn ->
-           {
-             :ok,
-             %{
-               connection: %{
-                 pid: self()
-               },
-               channel: channel
-             }
-           }
-         end
-       )
+      :connect,
+      fn ->
+        {:ok, connection}
+      end
+    )
+    |> expect(
+      :get_channel,
+      fn ^connection ->
+        {:ok, channel}
+      end
+    )
 
     {:ok, pid} = Connection.start_link()
-    assert Connection.channel(pid) == channel
+    assert Connection.publisher_channel(pid) == channel
   end
 
   test "consumes exchange and queue" do
     channel = %{name: "some channel"}
-    spec = %{exchange: "experts", queue: "are_es", consumer: self()}
+    connection = %{pid: self()}
+
+    spec = %{
+      exchange: "experts",
+      queue: "are_es",
+      consumer_pid: self(),
+      consumer_module: AModule
+    }
+
     StreamMock
     |> expect(
-         :connect,
-         fn ->
-           {
-             :ok,
-             %{
-               connection: %{
-                 pid: self()
-               },
-               channel: channel
-             }
-           }
-         end
-       )
+      :connect,
+      fn ->
+        {
+          :ok,
+          connection
+        }
+      end
+    )
     |> expect(
-         :bind_queue,
-         fn ^channel, ^spec ->
-           :ok
-         end
-       )
+      :get_channel,
+      fn ^connection ->
+        {:ok, channel}
+      end
+    )
+    |> expect(
+      :get_channel_from_cache,
+      fn ^connection, %{}, AModule ->
+        {:ok, %{channel: channel}, channel}
+      end
+    )
+    |> expect(
+      :bind_queue,
+      fn ^channel, ^spec ->
+        :ok
+      end
+    )
 
     {:ok, pid} = Connection.start_link()
     {:ok, returned_channel} = Connection.consume(pid, spec)
     assert returned_channel == channel
   end
+
   test "returns error if consume request fails" do
     channel = %{name: "some channel"}
-    spec = %{exchange: "experts", queue: "are_es", consumer: self()}
+    connection = %{pid: self()}
+    spec = %{exchange: "experts", queue: "are_es", consumer_pid: self(), consumer_module: AModule}
+
     StreamMock
     |> expect(
-         :connect,
-         fn ->
-           {
-             :ok,
-             %{
-               connection: %{
-                 pid: self()
-               },
-               channel: channel
-             }
-           }
-         end
-       )
+      :connect,
+      fn ->
+        {:ok, connection}
+      end
+    )
     |> expect(
-         :bind_queue,
-         fn ^channel, ^spec ->
-           {:error, "Something Asploded"}
-         end
-       )
+      :get_channel,
+      fn ^connection ->
+        {:ok, channel}
+      end
+    )
+    |> expect(
+      :get_channel_from_cache,
+      fn ^connection, %{}, AModule ->
+        {:ok, %{channel: channel}, channel}
+      end
+    )
+    |> expect(
+      :bind_queue,
+      fn ^channel, ^spec ->
+        {:error, "Something Asploded"}
+      end
+    )
 
     {:ok, pid} = Connection.start_link()
     {:error, reason} = Connection.consume(pid, spec)

--- a/test/railway_ipc/consumer_test.exs
+++ b/test/railway_ipc/consumer_test.exs
@@ -12,19 +12,24 @@ defmodule RailwayIpc.ConsumerTest do
   setup do
     StreamMock
     |> stub(
-         :connect,
-         fn ->
-           {
-             :ok,
-             %{
-               connection: %{
-                 pid: self()
-               },
-               channel: "Channel Info"
-             }
-           }
-         end
-       )
+      :connect,
+      fn ->
+        {:ok, %{pid: self()}}
+      end
+    )
+    |> stub(
+      :get_channel,
+      fn _conn ->
+        {:ok, "Channel Info"}
+      end
+    )
+    |> stub(
+      :get_channel_from_cache,
+      fn connection, channels, consumer_module ->
+        {:ok, %{BatchConsumer => "Channel Info"}, "Channel Info"}
+      end
+    )
+
     Connection.start_link(name: Connection)
     :ok
   end
@@ -38,11 +43,17 @@ defmodule RailwayIpc.ConsumerTest do
   test "acks message when successful" do
     StreamMock
     |> expect(
-         :bind_queue,
-         fn "Channel Info", %{consumer: _pid, exchange: "experts", queue: "are_es_tee"} ->
-           :ok
-         end
-       )
+      :bind_queue,
+      fn "Channel Info",
+         %{
+           consumer_module: BatchConsumer,
+           consumer_pid: _pid,
+           exchange: "experts",
+           queue: "are_es_tee"
+         } ->
+        :ok
+      end
+    )
     |> expect(:ack, fn "Channel Info", "tag" -> :ok end)
 
     {:ok, pid} = BatchConsumer.start_link(:ok)
@@ -51,17 +62,25 @@ defmodule RailwayIpc.ConsumerTest do
     PayloadMock
     |> expect(:decode, fn ^message -> {:ok, %{message: message}} end)
 
-    send pid, {:basic_deliver, message, %{delivery_tag: "tag"}}
-    Process.sleep(100) # yey async programming
+    send(pid, {:basic_deliver, message, %{delivery_tag: "tag"}})
+    # yey async programming
+    Process.sleep(100)
   end
+
   test "acks message even if there's an issue with the payload" do
     StreamMock
     |> expect(
-         :bind_queue,
-         fn "Channel Info", %{consumer: _pid, exchange: "experts", queue: "are_es_tee"} ->
-           :ok
-         end
-       )
+      :bind_queue,
+      fn "Channel Info",
+         %{
+           consumer_module: BatchConsumer,
+           consumer_pid: _pid,
+           exchange: "experts",
+           queue: "are_es_tee"
+         } ->
+        :ok
+      end
+    )
     |> expect(:ack, fn "Channel Info", "tag" -> :ok end)
 
     {:ok, pid} = BatchConsumer.start_link(:ok)
@@ -70,7 +89,8 @@ defmodule RailwayIpc.ConsumerTest do
     PayloadMock
     |> expect(:decode, fn ^message -> {:error, "Kaboom"} end)
 
-    send pid, {:basic_deliver, message, %{delivery_tag: "tag"}}
-    Process.sleep(100) # yey async programming
+    send(pid, {:basic_deliver, message, %{delivery_tag: "tag"}})
+    # yey async programming
+    Process.sleep(100)
   end
 end

--- a/test/railway_ipc/rabbit_mq/payload_test.exs
+++ b/test/railway_ipc/rabbit_mq/payload_test.exs
@@ -30,10 +30,14 @@ defmodule RailwayIpc.RabbitMQ.PayloadTest do
   end
 
   test "returns an error if given bad JSON" do
-    json = %{bogus_key: "Banana"}
-           |> Jason.encode!
+    json =
+      %{bogus_key: "Banana"}
+      |> Jason.encode!()
+
     {:error, reason} = Payload.decode(json)
-    assert reason == "Missing keys: {\"bogus_key\":\"Banana\"}. Expecting type and encoded_message keys"
+
+    assert reason ==
+             "Missing keys: {\"bogus_key\":\"Banana\"}. Expecting type and encoded_message keys"
   end
 
   test "returns an error if given bad data" do
@@ -42,13 +46,15 @@ defmodule RailwayIpc.RabbitMQ.PayloadTest do
   end
 
   test "returns an error if anything other than a string given" do
-    {:error, reason} = Payload.decode(123123)
+    {:error, reason} = Payload.decode(123_123)
     assert reason == "Malformed JSON given: 123123. Must be a string"
   end
 
   test "returns an error if the module is unknown after decoding" do
-    json = %{type: "BogusModule", encoded_message: ""}
-           |> Jason.encode!
+    json =
+      %{type: "BogusModule", encoded_message: ""}
+      |> Jason.encode!()
+
     {:error, reason} = Payload.decode(json)
     assert reason == "Unknown message type BogusModule"
   end

--- a/test/support/ipc/messages/create_batch.ex
+++ b/test/support/ipc/messages/create_batch.ex
@@ -3,19 +3,19 @@ defmodule Commands.CreateBatch do
   use Protobuf, syntax: :proto3
 
   @type t :: %__MODULE__{
-               user_id:        integer,
-               correlation_id: integer,
-               uuid:           String.t,
-               type:           String.t,
-               data:           Commands.CreateBatch.Data.t | nil
-             }
+          user_id: integer,
+          correlation_id: integer,
+          uuid: String.t(),
+          type: String.t(),
+          data: Commands.CreateBatch.Data.t() | nil
+        }
   defstruct [:user_id, :correlation_id, :uuid, :type, :data]
 
-  field :user_id, 1, type: :int32
-  field :correlation_id, 2, type: :int32
-  field :uuid, 3, type: :string
-  field :type, 4, type: :string
-  field :data, 5, type: Commands.CreateBatch.Data
+  field(:user_id, 1, type: :int32)
+  field(:correlation_id, 2, type: :int32)
+  field(:uuid, 3, type: :string)
+  field(:type, 4, type: :string)
+  field(:data, 5, type: Commands.CreateBatch.Data)
 end
 
 defmodule Commands.CreateBatch.Data do
@@ -23,9 +23,9 @@ defmodule Commands.CreateBatch.Data do
   use Protobuf, syntax: :proto3
 
   @type t :: %__MODULE__{
-               iteration: String.t
-             }
+          iteration: String.t()
+        }
   defstruct [:iteration]
 
-  field :iteration, 1, type: :string
+  field(:iteration, 1, type: :string)
 end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,3 +1,2 @@
 Mox.defmock(RailwayIpc.StreamMock, for: RailwayIpc.StreamBehaviour)
 Mox.defmock(RailwayIpc.PayloadMock, for: RailwayIpc.PayloadBehaviour)
-


### PR DESCRIPTION
Make a channel per consumer per the Rabbit Docs, for better multiplexing. This also allows the calling app start the rabbit connection allowing for a "let it fail" strategy. Consumers are started under a separate supervisor to allow for individual consumer failure not restarting all other children. However if a catastrophic failure does happen to all consumers, it will restart the supervisor, which will restart the connection.
