### PR TITLE
bump version of package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule RailwayIpc.MixProject do
   def project do
     [
       app: :railway_ipc,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
ran into the following error while publishing: 
`Publishing failed
  inserted_at: can only modify a release up to one hour after creation`

Increased the version to account for that problem