### PR TITLE
add priv dir to release path; bump version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule RailwayIpc.MixProject do
   def project do
     [
       app: :railway_ipc,
-      version: "0.1.6",
+      version: "0.1.7",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -46,7 +46,7 @@ defmodule RailwayIpc.MixProject do
   end
 
   defp elixirc_paths(:test), do: ["test/support", "lib"]
-  defp elixirc_paths(_), do: ["lib"]
+  defp elixirc_paths(_), do: ["lib", "priv"]
 
   defp package() do
     [


### PR DESCRIPTION
Latest release does not include `priv/` dir in the release path. This is where migration templates live so new apps including Railway will fail to successfully execute the railway "generate migrations" mix task. Missed this cuz I generated migrations in Course Conductor using the local version of Railway before upgrading and shipping. 