### PR TITLE
Fix migration gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ erl_crash.dump
 railway_ipc-*.tar
 
 .envrc
+
+# Version Manager
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -17,12 +17,21 @@ end
 
 ## Getting Started
 
+Configure Railway to work with your Repo. Add the following to your `config/config.exs`:
+
+```elixir
+config :railway_ipc,
+  repo: ApplicationName.Repo
+```
+
 Run the mix task to generate the migrations to add the published messages and consumed messages tables to your app's DB:
 
 ```bash
-mix railway_ipc.generate_migrations
+mix railway_ipc.generate_migrations ./path/to/migration/directory
 mix ecto.migrate
 ```
+
+> Note: Path to migration directory defaults to `./priv/repo/migrations` if none is passed in.
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm).

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ mix ecto.migrate
 
 > Note: Path to migration directory defaults to `./priv/repo/migrations` if none is passed in.
 
+**If there are issues running the migration or deploying the migration, try manually writing the name of the migration module (not the file) to avoid using interpolation.**
+
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm).
 Once published, the docs can

--- a/lib/mix/support/migration_helper.ex
+++ b/lib/mix/support/migration_helper.ex
@@ -1,0 +1,17 @@
+defmodule Mix.Support.MigrationHelper do
+
+  def get_migrations_path([path]), do: path
+  def get_migrations_path([]), do: "./priv/repo/migrations"
+
+  def timestamp do
+    {{y, m, d}, {hh, mm, ss}} = :calendar.universal_time()
+    "#{y}#{pad(m)}#{pad(d)}#{pad(hh)}#{pad(mm)}#{pad(ss)}"
+  end
+
+  defp pad(i) when i < 10 do
+    to_string(i)
+    |> String.pad_leading(2, ["0"])
+  end
+
+  defp pad(i), do: to_string(i)
+end

--- a/lib/mix/support/system_command_helper.ex
+++ b/lib/mix/support/system_command_helper.ex
@@ -1,0 +1,18 @@
+defmodule Mix.Support.SystemCommandHelper do
+  def run_system_command(command) when is_binary(command) do
+    command
+    |> String.to_charlist()
+    |> run_system_command()
+  end
+
+  def run_system_command(command) do
+    response =
+      command
+      |> :os.cmd()
+      |> to_string()
+
+    if response != "" do
+      raise response
+    end
+  end
+end

--- a/lib/mix/tasks/generate_alter_table_migrations.ex
+++ b/lib/mix/tasks/generate_alter_table_migrations.ex
@@ -1,33 +1,32 @@
 defmodule Mix.Tasks.RailwayIpc.GenerateAlterTableMigrations do
-  use Mix.Task
-  @shortdoc "Generates migrations for Railway IPC message persistence"
-  def run(_arg) do
-    IO.puts("Generating  Railway IPC alter messages tables migration...")
+  @moduledoc """
+  Mix task for generating Railway migration files
 
-    alter_table_migrations_command()
-    |> :os.cmd()
+  Run with `mix railway_ipc.generate_alter_table_migrations ./path/to/migrations`
+  If not path is passed in, the task will default to `./priv/repo/migrations`
+  """
+
+  use Mix.Task
+
+  import Mix.Support.{MigrationHelper, SystemCommandHelper}
+
+  @shortdoc "Generates migrations for Railway IPC message persistence"
+  def run(args) do
+    IO.puts("Generating  Railway IPC alter messages tables migration...")
+    path_to_migrations = get_migrations_path(args)
+
+    path_to_migrations
+    |> alter_table_migrations_command()
+    |> run_system_command()
 
     Process.sleep(:timer.seconds(1))
 
     IO.puts("Generated alter table migration successfully. Run `mix ecto.migrate`")
   end
 
-  defp alter_table_migrations_command do
-    "cp ./deps/railway_ipc/priv/repo/migrations/03_alter_messages_tables.exs ./priv/repo/migrations/#{
+  defp alter_table_migrations_command(path_to_migrations) do
+    "cp ./deps/railway_ipc/priv/repo/migrations/03_alter_messages_tables.exs #{path_to_migrations}/#{
       timestamp()
     }_alter_messages_tables.exs"
-    |> String.to_charlist()
   end
-
-  defp timestamp do
-    {{y, m, d}, {hh, mm, ss}} = :calendar.universal_time()
-    "#{y}#{pad(m)}#{pad(d)}#{pad(hh)}#{pad(mm)}#{pad(ss)}"
-  end
-
-  defp pad(i) when i < 10 do
-    to_string(i)
-    |> String.pad_leading(2, ["0"])
-  end
-
-  defp pad(i), do: to_string(i)
 end

--- a/lib/mix/tasks/generate_alter_table_migrations.ex
+++ b/lib/mix/tasks/generate_alter_table_migrations.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.RailwayIpc.GenerateAlterTableMigrations do
   Mix task for generating Railway migration files
 
   Run with `mix railway_ipc.generate_alter_table_migrations ./path/to/migrations`
-  If not path is passed in, the task will default to `./priv/repo/migrations`
+  If no path is passed in, the task will default to `./priv/repo/migrations`
   """
 
   use Mix.Task

--- a/lib/mix/tasks/generate_migrations.ex
+++ b/lib/mix/tasks/generate_migrations.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.RailwayIpc.GenerateMigrations do
   Mix task for generating Railway migration files
 
   Run with `mix railway_ipc.generate_migrations ./path/to/migrations`
-  If not path is passed in, the task will default to `./priv/repo/migrations`
+  If no path is passed in, the task will default to `./priv/repo/migrations`
   """
 
   use Mix.Task

--- a/lib/mix/tasks/generate_migrations.ex
+++ b/lib/mix/tasks/generate_migrations.ex
@@ -1,45 +1,44 @@
 defmodule Mix.Tasks.RailwayIpc.GenerateMigrations do
-  use Mix.Task
-  @shortdoc "Generates migrations for Railway IPC message persistence"
-  def run(_arg) do
-    IO.puts("Generating  Railway IPC published messages migration...")
+  @moduledoc """
+  Mix task for generating Railway migration files
 
-    published_messages_command()
-    |> :os.cmd()
+  Run with `mix railway_ipc.generate_migrations ./path/to/migrations`
+  If not path is passed in, the task will default to `./priv/repo/migrations`
+  """
+
+  use Mix.Task
+
+  import Mix.Support.{MigrationHelper, SystemCommandHelper}
+
+  @shortdoc "Generates migrations for Railway IPC message persistence"
+  def run(args) do
+    IO.puts("Generating  Railway IPC published messages migration...")
+    path_to_migrations = get_migrations_path(args)
+
+    path_to_migrations
+    |> published_messages_command()
+    |> run_system_command()
 
     Process.sleep(:timer.seconds(1))
 
     IO.puts("Generating  Railway IPC consumed messages migration...")
 
-    consumed_messages_command()
-    |> :os.cmd()
+    path_to_migrations
+    |> consumed_messages_command()
+    |> run_system_command()
 
     IO.puts("Generated migrations successfully. Run `mix ecto.migrate`")
   end
 
-  defp published_messages_command do
-    "cp ./deps/railway_ipc/priv/repo/migrations/01_create_railway_ipc_published_messages.exs ./priv/repo/migrations/#{
+  defp published_messages_command(path_to_migrations) do
+    "cp ./deps/railway_ipc/priv/repo/migrations/01_create_railway_ipc_published_messages.exs #{path_to_migrations}/#{
       timestamp()
     }_create_railway_ipc_published_messages.exs"
-    |> String.to_charlist()
   end
 
-  defp consumed_messages_command do
-    "cp ./deps/railway_ipc/priv/repo/migrations/02_create_railway_ipc_consumed_messages.exs ./priv/repo/migrations/#{
+  defp consumed_messages_command(path_to_migrations) do
+    "cp ./deps/railway_ipc/priv/repo/migrations/02_create_railway_ipc_consumed_messages.exs #{path_to_migrations}/#{
       timestamp()
     }_create_railway_ipc_consumed_messages.exs"
-    |> String.to_charlist()
   end
-
-  defp timestamp do
-    {{y, m, d}, {hh, mm, ss}} = :calendar.universal_time()
-    "#{y}#{pad(m)}#{pad(d)}#{pad(hh)}#{pad(mm)}#{pad(ss)}"
-  end
-
-  defp pad(i) when i < 10 do
-    to_string(i)
-    |> String.pad_leading(2, ["0"])
-  end
-
-  defp pad(i), do: to_string(i)
 end

--- a/lib/mix/tasks/generate_remove_exchange_constraint_migration.ex
+++ b/lib/mix/tasks/generate_remove_exchange_constraint_migration.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.RailwayIpc.GenerateRemoveExchangeConstraintMigration do
   Mix task for generating Railway migration files
 
   Run with `mix railway_ipc.generate_remove_exchange_constraint_migration ./path/to/migrations`
-  If not path is passed in, the task will default to `./priv/repo/migrations`
+  If no path is passed in, the task will default to `./priv/repo/migrations`
   """
 
   import Mix.Support.{MigrationHelper, SystemCommandHelper}

--- a/lib/mix/tasks/generate_remove_exchange_constraint_migration.ex
+++ b/lib/mix/tasks/generate_remove_exchange_constraint_migration.ex
@@ -1,11 +1,22 @@
 defmodule Mix.Tasks.RailwayIpc.GenerateRemoveExchangeConstraintMigration do
   use Mix.Task
-  @shortdoc "Generates migrations to remove constraint on exchange"
-  def run(_arg) do
-    IO.puts("Generating migrations to remove constraint on exchange")
+  @moduledoc """
+  Mix task for generating Railway migration files
 
-    remove_exchange_constraint_command()
-    |> :os.cmd()
+  Run with `mix railway_ipc.generate_remove_exchange_constraint_migration ./path/to/migrations`
+  If not path is passed in, the task will default to `./priv/repo/migrations`
+  """
+
+  import Mix.Support.{MigrationHelper, SystemCommandHelper}
+
+  @shortdoc "Generates migrations to remove constraint on exchange"
+  def run(args) do
+    IO.puts("Generating migrations to remove constraint on exchange")
+    path_to_migrations = get_migrations_path(args)
+
+    path_to_migrations
+    |> remove_exchange_constraint_command()
+    |> run_system_command()
 
     Process.sleep(:timer.seconds(1))
 
@@ -14,22 +25,9 @@ defmodule Mix.Tasks.RailwayIpc.GenerateRemoveExchangeConstraintMigration do
     )
   end
 
-  defp remove_exchange_constraint_command do
-    "cp ./deps/railway_ipc/priv/repo/migrations/04_remove_constraint_on_exchange.exs ./priv/repo/migrations/#{
+  defp remove_exchange_constraint_command(path_to_migrations) do
+    "cp ./deps/railway_ipc/priv/repo/migrations/04_remove_constraint_on_exchange.exs #{path_to_migrations}/#{
       timestamp()
     }_remove_constraint_on_exchange.exs"
-    |> String.to_charlist()
   end
-
-  defp timestamp do
-    {{y, m, d}, {hh, mm, ss}} = :calendar.universal_time()
-    "#{y}#{pad(m)}#{pad(d)}#{pad(hh)}#{pad(mm)}#{pad(ss)}"
-  end
-
-  defp pad(i) when i < 10 do
-    to_string(i)
-    |> String.pad_leading(2, ["0"])
-  end
-
-  defp pad(i), do: to_string(i)
 end

--- a/lib/mix/tasks/update_protobufs.ex
+++ b/lib/mix/tasks/update_protobufs.ex
@@ -1,8 +1,11 @@
 defmodule Mix.Tasks.GenerateTestProtobufs do
   use Mix.Task
+
+  import Mix.Support.SystemCommandHelper
+
   @shortdoc "Generates test protobufs"
   def run(_arg) do
-    :os.cmd(
+    run_system_command(
       'protoc --proto_path=test/support/ipc/protobuf --elixir_out=test/support/ipc/messages test/support/ipc/protobuf/*.proto'
     )
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule RailwayIpc.MixProject do
   def project do
     [
       app: :railway_ipc,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule RailwayIpc.MixProject do
   def project do
     [
       app: :railway_ipc,
-      version: "0.2.1",
+      version: "0.2.0",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Issues:
- On our current version, the generate command appears to work fine even if system commands fail
- Current version assumes the location of migrations, but migrations may be in a different place in the case of an umbrella app

Fix:
- Raise if system command fails
- Allow for the ability to pass in a location for migrations