### PR TITLE
Add Consumer Group abstraction

### DIFF
--- a/lib/railway_ipc/consumer_group/consumer_monitor.ex
+++ b/lib/railway_ipc/consumer_group/consumer_monitor.ex
@@ -1,0 +1,28 @@
+defmodule RailwayIpc.ConsumerGroup.ConsumerMonitor do
+  use GenServer, restart: :transient
+  alias RailwayIpc.ConsumerGroup.Supervisor, as: CGSupervisor
+
+  def start_link(supervisor) do
+    GenServer.start_link(__MODULE__, supervisor)
+  end
+
+  def init(supervisor) do
+    {:ok, %{supervisor: supervisor}, {:continue, :monitor}}
+  end
+
+  def handle_continue(:monitor, %{supervisor: supervisor} = state) do
+    for pid <- CGSupervisor.consumer_pids(supervisor) do
+      Process.monitor(pid)
+    end
+
+    {:noreply, state}
+  end
+
+  def handle_info(
+        {:DOWN, _ref, :process, _pid, _reason},
+        %{supervisor: supervisor} = state
+      ) do
+    CGSupervisor.stop_consumers(supervisor)
+    {:stop, :normal, state}
+  end
+end

--- a/lib/railway_ipc/consumer_group/consumer_supervisor.ex
+++ b/lib/railway_ipc/consumer_group/consumer_supervisor.ex
@@ -1,0 +1,21 @@
+defmodule RailwayIpc.ConsumerGroup.ConsumerSupervisor do
+  use Supervisor
+
+  def start_link(children) do
+    Supervisor.start_link(__MODULE__, children)
+  end
+
+  def consumer_pids(supervisor) do
+    for {_, pid, _, _} <- Supervisor.which_children(supervisor), do: pid
+  end
+
+  def stop_consumers(supervisor) do
+    for pid <- consumer_pids(supervisor) do
+      GenServer.stop(pid)
+    end
+  end
+
+  def init(children) do
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/lib/railway_ipc/consumer_group/supervisor.ex
+++ b/lib/railway_ipc/consumer_group/supervisor.ex
@@ -5,6 +5,10 @@ defmodule RailwayIpc.ConsumerGroup.Supervisor do
     Supervisor.start_link(__MODULE__, children, name: name)
   end
 
+  def setup_group(children: children, name: name) when is_atom(name) do
+    Supervisor.child_spec({__MODULE__, [children: children, name: name]}, id: name)
+  end
+
   def consumer_supervisor(pid) do
     Supervisor.which_children(pid)
     |> Enum.find_value(fn {module, child_pid, _, _} ->

--- a/lib/railway_ipc/consumer_group/supervisor.ex
+++ b/lib/railway_ipc/consumer_group/supervisor.ex
@@ -1,0 +1,45 @@
+defmodule RailwayIpc.ConsumerGroup.Supervisor do
+  use Supervisor
+
+  def start_link(children: children, name: name) when is_atom(name) do
+    Supervisor.start_link(__MODULE__, children, name: name)
+  end
+
+  def consumer_supervisor(pid) do
+    Supervisor.which_children(pid)
+    |> Enum.find_value(fn {module, child_pid, _, _} ->
+      case module do
+        RailwayIpc.ConsumerGroup.ConsumerSupervisor -> child_pid
+        _ -> nil
+      end
+    end)
+  end
+
+  def restart_tree(pid) do
+    pid
+    |> consumer_supervisor
+    |> Supervisor.stop()
+  end
+
+  def consumer_pids(pid) do
+    pid
+    |> consumer_supervisor
+    |> RailwayIpc.ConsumerGroup.ConsumerSupervisor.consumer_pids()
+  end
+
+  def stop_consumers(pid) do
+    pid
+    |> consumer_supervisor
+    |> RailwayIpc.ConsumerGroup.ConsumerSupervisor.stop_consumers()
+  end
+
+  @impl true
+  def init(children) do
+    children = [
+      {RailwayIpc.ConsumerGroup.ConsumerSupervisor, children},
+      {RailwayIpc.ConsumerGroup.ConsumerMonitor, self()}
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+end

--- a/test/railway_ipc/consumer_group/supervisor_test.exs
+++ b/test/railway_ipc/consumer_group/supervisor_test.exs
@@ -1,0 +1,76 @@
+defmodule RailwayIpc.ConsumerGroup.SupervisorTest do
+  use ExUnit.Case
+  import Mox
+  alias RailwayIpc.ConsumerGroup.Supervisor, as: CGSupervisor
+  setup :set_mox_global
+
+  test "starts consumers in the group" do
+    start_opts = [
+      children: [
+        RailwayIpc.Test.BatchEventsConsumer,
+        RailwayIpc.Test.BatchCommandsConsumer
+      ],
+      name: :batch_consumers
+    ]
+
+    RailwayIpc.StreamMock
+    |> expect(:setup_exchange_and_queue, 2, fn _, _, _ -> :ok end)
+    |> expect(:consume, 2, fn _, _, _, _ -> {:ok, "My Tag"} end)
+
+    {:ok, _supervisor} = start_supervised({CGSupervisor, start_opts})
+    Process.sleep(100)
+
+    assert RailwayIpc.Test.BatchEventsConsumer |> Process.whereis() |> Process.alive?()
+  end
+
+  test "stops all members of the group if one dies" do
+    start_opts = [
+      children: [
+        RailwayIpc.Test.BatchEventsConsumer,
+        RailwayIpc.Test.BatchCommandsConsumer
+      ],
+      name: :batch_consumers
+    ]
+
+    RailwayIpc.StreamMock
+    |> expect(:setup_exchange_and_queue, 2, fn _, _, _ -> :ok end)
+    |> expect(:consume, 2, fn _, _, _, _ -> {:ok, "My Tag"} end)
+
+    {:ok, _supervisor} = start_supervised({CGSupervisor, start_opts})
+
+    RailwayIpc.Test.BatchEventsConsumer
+    |> Process.whereis()
+    |> GenServer.stop()
+
+    Process.sleep(100)
+
+    refute RailwayIpc.Test.BatchCommandsConsumer |> Process.whereis()
+  end
+
+  test "Brings back children successfully" do
+    start_opts = [
+      children: [
+        RailwayIpc.Test.BatchEventsConsumer,
+        RailwayIpc.Test.BatchCommandsConsumer
+      ],
+      name: :batch_consumers
+    ]
+
+    RailwayIpc.StreamMock
+    |> expect(:setup_exchange_and_queue, 4, fn _, _, _ -> :ok end)
+    |> expect(:consume, 4, fn _, _, _, _ -> {:ok, "My Tag"} end)
+
+    {:ok, _supervisor} = start_supervised({CGSupervisor, start_opts})
+
+    RailwayIpc.Test.BatchEventsConsumer
+    |> Process.whereis()
+    |> GenServer.stop()
+
+    Process.sleep(100)
+
+    CGSupervisor.restart_tree(:batch_consumers)
+    Process.sleep(100)
+    assert RailwayIpc.Test.BatchEventsConsumer |> Process.whereis() |> Process.alive?()
+    assert RailwayIpc.Test.BatchCommandsConsumer |> Process.whereis() |> Process.alive?()
+  end
+end


### PR DESCRIPTION
# Consumer Groups
Failure is hard. This PR introduces a way to group consumers you _want_ to fail together.

## Usage
To Group a set of consumers together You would add this to your supervision tree
```elixir
children = [
#... more things
  RailwayIpc.ConsumerGroup.Supervisor.setup_group(children:[Consumer1, Consumer2],
    name: :unique_name_for_this_consumer_group)
# start your supervisor
```
This will make it so that ANY of these consumers crashing, brings down ONLY other consumers in this consumer group.

## When would you need this?
There are consumers in our system where failure could lead to either inconsistent data being sent to 3rd party systems or failures in different consumers "at a distance". A failure to integrate a new Campus into our DB may not break ALL new Cohorts, but it will as soon as someone tries to add Cohort for that Campus. 

Other times, failures may not affect other parts of the application if they fail. For instance, we can allow for a failure to sync Cohort information to SFDC to only fail Consumers that send information to SFDC, but leave the ones that register students to cohort alone.

Previous approaches to failure were heavy handed and stopped ALL consumers. This works if the application is small and has one purpose. With larger applications however we may have several disparate concerns that can continue to operate even if one part of the system is dealing with an outage.

# Restarting the tree
In the event that the reason your consumer group crashed was a _bad message_, simply remove the bad message from the queue, and restart your tree using `RailwayIpc.ConsumerGroup.Supervisor.restart_tree(:unique_name_for_this_consumer_group)`. This allows you to restart workers without having to deploy. The application a new.

Here's an example of isolated groups only crashing their peers.
![failure_groups](https://user-images.githubusercontent.com/325485/92976916-a2463c00-f459-11ea-8458-d42a4c10d171.gif)
Here's an example of how you'd set this up:
![image](https://user-images.githubusercontent.com/325485/92976978-bee27400-f459-11ea-97cc-cbc710b4ec55.png)

