### PR TITLE
Generate connection map from url

### DIFF
--- a/lib/railway_ipc/consumer_pool.ex
+++ b/lib/railway_ipc/consumer_pool.ex
@@ -1,7 +1,10 @@
 defmodule RailwayIpc.ConsumerPool do
   @consumer_max_channels Application.get_env(:railway_ipc, :consumer_max_channels, 10)
+  import RailwayIpc.RabbitMQ.RabbitMQAdapter, only: [connection_options: 0]
+
   def rabbitmq_config do
     [channels: @consumer_max_channels]
+    |> Keyword.merge(connection_options())
   end
 
   def connection_pools do

--- a/lib/railway_ipc/publisher_pool.ex
+++ b/lib/railway_ipc/publisher_pool.ex
@@ -1,7 +1,10 @@
 defmodule RailwayIpc.PublisherPool do
   @publisher_max_channels Application.get_env(:railway_ipc, :publisher_max_channels, 2)
+  import RailwayIpc.RabbitMQ.RabbitMQAdapter, only: [connection_options: 0]
+
   def rabbitmq_config do
     [channels: @publisher_max_channels]
+    |> Keyword.merge(connection_options())
   end
 
   def connection_pools do

--- a/lib/railway_ipc/rabbit_mq/rabbit_mq_adapter.ex
+++ b/lib/railway_ipc/rabbit_mq/rabbit_mq_adapter.ex
@@ -9,6 +9,31 @@ defmodule RailwayIpc.RabbitMQ.RabbitMQAdapter do
       raise "Must set config value :railway_ipc, :rabbitmq_connection_url, or export environment variable RABBITMQ_CONNECTION_URL"
   end
 
+  # Converting Erlang Record to options we can use to connect with via AMQP.
+  # https://github.com/rabbitmq/rabbitmq-erlang-client/blob/0f8f6f5a9f1f4b5866706df3e66eb6e66579cd3e/include/amqp_client.hrl
+  def connection_options do
+    {:ok,
+     {:amqp_params_network, username, password, virtual_host, host, port, channel_max, frame_max,
+      heart_beat, connection_timeout, ssl_options, auth_mechanisms, client_properties,
+      socket_options}} = :amqp_uri.parse(connection_url())
+
+    [
+      username: username,
+      password: password,
+      virtual_host: virtual_host,
+      host: host,
+      port: port,
+      channel_max: channel_max,
+      frame_max: frame_max,
+      heart_beat: heart_beat,
+      connection_timeout: connection_timeout,
+      ssl_options: ssl_options,
+      auth_mechanisms: auth_mechanisms,
+      client_properties: client_properties,
+      socket_options: socket_options
+    ]
+  end
+
   def connect do
     Telemetry.track_connecting_to_rabbit(fn ->
       with {:ok, connection} when not is_nil(connection) <-

--- a/lib/railway_ipc/rpc_pool.ex
+++ b/lib/railway_ipc/rpc_pool.ex
@@ -1,7 +1,10 @@
 defmodule RailwayIpc.RPCPool do
   @rpc_max_channels Application.get_env(:railway_ipc, :rpc_max_channels, 10)
+  import RailwayIpc.RabbitMQ.RabbitMQAdapter, only: [connection_options: 0]
+
   def rabbitmq_config do
     [channels: @rpc_max_channels]
+    |> Keyword.merge(connection_options())
   end
 
   def connection_pools do


### PR DESCRIPTION
ExRabbitPool expects the connection credentials and configuration to be passed in as options instead of the connection url. This PR parses the url and puts it in a keyword list.