### PR TITLE
Cleanup moduledoc credo warnings

### DIFF
--- a/lib/mix/support/migration_helper.ex
+++ b/lib/mix/support/migration_helper.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Support.MigrationHelper do
+  @moduledoc false
   def get_migrations_path([path]), do: path
   def get_migrations_path([]), do: "./priv/repo/migrations"
 

--- a/lib/mix/support/system_command_helper.ex
+++ b/lib/mix/support/system_command_helper.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Support.SystemCommandHelper do
+  @moduledoc false
   def run_system_command(command) when is_binary(command) do
     command
     |> String.to_charlist()

--- a/lib/mix/tasks/update_protobufs.ex
+++ b/lib/mix/tasks/update_protobufs.ex
@@ -1,4 +1,5 @@
 defmodule Mix.Tasks.GenerateTestProtobufs do
+  @moduledoc false
   use Mix.Task
 
   import Mix.Support.SystemCommandHelper

--- a/lib/railway_ipc.ex
+++ b/lib/railway_ipc.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc do
+  @moduledoc false
   alias RailwayIpc.Ipc.RepublishedMessagesPublisher
   @behaviour RailwayIpcBehaviour
 

--- a/lib/railway_ipc/command_message_handler.ex
+++ b/lib/railway_ipc/command_message_handler.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.CommandMessageHandler do
+  @moduledoc false
   def handle_message(message, handle_module) do
     case handle_module.handle_in(message) do
       :ok ->

--- a/lib/railway_ipc/commands_consumer.ex
+++ b/lib/railway_ipc/commands_consumer.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.CommandsConsumer do
+  @moduledoc false
   defmacro __using__(opts) do
     quote do
       require Logger

--- a/lib/railway_ipc/connection.ex
+++ b/lib/railway_ipc/connection.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Connection do
+  @moduledoc false
   @stream_adapter Application.get_env(
                     :railway_ipc,
                     :stream_adapter,

--- a/lib/railway_ipc/consumed_message.ex
+++ b/lib/railway_ipc/consumed_message.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.ConsumedMessage do
+  @moduledoc false
   @persistence Application.get_env(:railway_ipc, :persistence, RailwayIpc.Persistence)
 
   def get(uuid) do

--- a/lib/railway_ipc/core/command_message.ex
+++ b/lib/railway_ipc/core/command_message.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Core.CommandMessage do
+  @moduledoc false
   alias RailwayIpc.Core.Payload
 
   defstruct ~w[encoded_message decoded_message type]a

--- a/lib/railway_ipc/core/commands_consumer.ex
+++ b/lib/railway_ipc/core/commands_consumer.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Core.CommandsConsumer do
+  @moduledoc false
   require Logger
   alias RailwayIpc.Core.CommandMessage
 

--- a/lib/railway_ipc/core/event_message.ex
+++ b/lib/railway_ipc/core/event_message.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Core.EventMessage do
+  @moduledoc false
   defstruct ~w[encoded_message decoded_message type]a
 
   alias RailwayIpc.Core.Payload

--- a/lib/railway_ipc/core/events_consumer.ex
+++ b/lib/railway_ipc/core/events_consumer.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Core.EventsConsumer do
+  @moduledoc false
   require Logger
   alias RailwayIpc.Core.EventMessage
   alias RailwayIpc.Telemetry

--- a/lib/railway_ipc/core/message_consumption_result.ex
+++ b/lib/railway_ipc/core/message_consumption_result.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Core.MessageConsumptionResult do
+  @moduledoc false
   defstruct [:status, :reason]
 
   def new({status, reason}) do

--- a/lib/railway_ipc/core/payload.ex
+++ b/lib/railway_ipc/core/payload.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Core.Payload do
+  @moduledoc false
   @behaviour RailwayIpc.PayloadBehaviour
   import RailwayIpc.Utils, only: [module_defined?: 1]
 

--- a/lib/railway_ipc/core/published_message.ex
+++ b/lib/railway_ipc/core/published_message.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Core.PublishedMessage do
+  @moduledoc false
   defstruct ~w[encoded_message decoded_message type]a
   alias alias RailwayIpc.Core.Payload
 

--- a/lib/railway_ipc/core/requests_consumer.ex
+++ b/lib/railway_ipc/core/requests_consumer.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Core.RequestsConsumer do
+  @moduledoc false
   require Logger
   alias RailwayIpc.Telemetry
   alias RailwayIpc.Core.Payload

--- a/lib/railway_ipc/core/routing_info.ex
+++ b/lib/railway_ipc/core/routing_info.ex
@@ -1,3 +1,4 @@
 defmodule RailwayIpc.Core.RoutingInfo do
+  @moduledoc false
   defstruct queue: nil, exchange: nil
 end

--- a/lib/railway_ipc/events_consumer.ex
+++ b/lib/railway_ipc/events_consumer.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.EventsConsumer do
+  @moduledoc false
   defmacro __using__(opts) do
     quote do
       require Logger

--- a/lib/railway_ipc/ipc/adapters/republished_message_adapter.ex
+++ b/lib/railway_ipc/ipc/adapters/republished_message_adapter.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Ipc.RepublishedMessageAdapter do
+  @moduledoc false
   alias RailwayIpc.Commands.RepublishMessage
 
   def republish_message(published_message_uuid, %{

--- a/lib/railway_ipc/ipc/consumers/republished_messages_consumer.ex
+++ b/lib/railway_ipc/ipc/consumers/republished_messages_consumer.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Ipc.RepublishedMessagesConsumer do
+  @moduledoc false
   use RailwayIpc.RepublishCommandConsumer,
     queue: "railway_ipc:republished_messages:commands"
 

--- a/lib/railway_ipc/ipc/logger.ex
+++ b/lib/railway_ipc/ipc/logger.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Ipc.Logger do
+  @moduledoc false
   require Logger
 
   def log_republishing_message(message) do

--- a/lib/railway_ipc/ipc/publishers/republished_messages_publisher.ex
+++ b/lib/railway_ipc/ipc/publishers/republished_messages_publisher.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Ipc.RepublishedMessagesPublisher do
+  @moduledoc false
   use RailwayIpc.Publisher,
     queue: "railway_ipc:republished_messages:commands"
 

--- a/lib/railway_ipc/loggers/consumer_events.ex
+++ b/lib/railway_ipc/loggers/consumer_events.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Loggers.ConsumerEvents do
+  @moduledoc false
   require Logger
   import RailwayIpc.Utils, only: [protobuf_to_json: 1]
 

--- a/lib/railway_ipc/loggers/publisher_events.ex
+++ b/lib/railway_ipc/loggers/publisher_events.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Loggers.PublisherEvents do
+  @moduledoc false
   require Logger
   import RailwayIpc.Utils, only: [protobuf_to_json: 1]
 

--- a/lib/railway_ipc/message_consumption.ex
+++ b/lib/railway_ipc/message_consumption.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.MessageConsumption do
+  @moduledoc false
   alias RailwayIpc.Core.{CommandMessage, EventMessage}
   alias RailwayIpc.Core.MessageConsumptionResult, as: Result
   alias RailwayIpc.CommandMessageHandler

--- a/lib/railway_ipc/message_consumption_behaviour.ex
+++ b/lib/railway_ipc/message_consumption_behaviour.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.MessageConsumptionBehaviour do
+  @moduledoc false
   alias RailwayIpc.Core.{EventMessage, CommandMessage}
 
   @callback process(String.t(), String.t(), String.t(), String.t(), EventMessage) ::

--- a/lib/railway_ipc/message_publihsing_behaviour.ex
+++ b/lib/railway_ipc/message_publihsing_behaviour.ex
@@ -1,3 +1,4 @@
 defmodule RailwayIpc.MessagePublishingBehaviour do
+  @moduledoc false
   @callback process(message :: Map.t(), routing_info :: Map.t()) :: tuple()
 end

--- a/lib/railway_ipc/message_publishing.ex
+++ b/lib/railway_ipc/message_publishing.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.MessagePublishing do
+  @moduledoc false
   alias RailwayIpc.Core.{RoutingInfo, PublishedMessage}
   alias RailwayIpc.PublishedMessage, as: PublishedMessageContext
   @behaviour RailwayIpc.MessagePublishingBehaviour

--- a/lib/railway_ipc/payload_behaviour.ex
+++ b/lib/railway_ipc/payload_behaviour.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.PayloadBehaviour do
+  @moduledoc false
   @callback decode(payload :: any()) :: {:ok, message :: map()} | {:error, error :: binary()}
   @callback encode(protobuf_struct :: map()) ::
               {:ok, message :: binary()} | {:error, error :: binary()}

--- a/lib/railway_ipc/persistence.ex
+++ b/lib/railway_ipc/persistence.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Persistence do
+  @moduledoc false
   @behaviour RailwayIpc.PersistenceBehaviour
   @repo Application.get_env(:railway_ipc, :repo, RailwayIpc.Dev.Repo)
   alias RailwayIpc.Persistence.{

--- a/lib/railway_ipc/persistence/consumed_message.ex
+++ b/lib/railway_ipc/persistence/consumed_message.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Persistence.ConsumedMessage do
+  @moduledoc false
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/railway_ipc/persistence/consumed_message_adapter.ex
+++ b/lib/railway_ipc/persistence/consumed_message_adapter.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Persistence.ConsumedMessageAdapter do
+  @moduledoc false
   alias RailwayIpc.Core.Payload
 
   def to_persistence(

--- a/lib/railway_ipc/persistence/persistence_behaviour.ex
+++ b/lib/railway_ipc/persistence/persistence_behaviour.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.PersistenceBehaviour do
+  @moduledoc false
   alias RailwayIpc.Persistence.{ConsumedMessage, PublishedMessage}
   @moduledoc false
   alias RailwayIpc.Persistence.ConsumedMessage

--- a/lib/railway_ipc/persistence/published_message.ex
+++ b/lib/railway_ipc/persistence/published_message.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Persistence.PublishedMessage do
+  @moduledoc false
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/railway_ipc/persistence/published_message_adapter.ex
+++ b/lib/railway_ipc/persistence/published_message_adapter.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Persistence.PublishedMessageAdapter do
+  @moduledoc false
   alias RailwayIpc.Core.PublishedMessage
 
   def to_persistence(

--- a/lib/railway_ipc/published_message.ex
+++ b/lib/railway_ipc/published_message.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.PublishedMessage do
+  @moduledoc false
   @persistence Application.get_env(:railway_ipc, :persistence, RailwayIpc.Persistence)
 
   def get(uuid) do

--- a/lib/railway_ipc/publisher.ex
+++ b/lib/railway_ipc/publisher.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Publisher do
+  @moduledoc false
   @stream_adapter Application.get_env(
                     :railway_ipc,
                     :stream_adapter,

--- a/lib/railway_ipc/rabbit_mq/rabbit_mq_adapter.ex
+++ b/lib/railway_ipc/rabbit_mq/rabbit_mq_adapter.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.RabbitMQ.RabbitMQAdapter do
+  @moduledoc false
   use AMQP
   @behaviour RailwayIpc.StreamBehaviour
   alias RailwayIpc.Telemetry

--- a/lib/railway_ipc/railway_ipc_behaviour.ex
+++ b/lib/railway_ipc/railway_ipc_behaviour.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpcBehaviour do
+  @moduledoc false
   @callback republish_message(published_message_uuid :: String.t(), request_data :: Map.t()) ::
               atom()
 end

--- a/lib/railway_ipc/repo.ex
+++ b/lib/railway_ipc/repo.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Dev.Repo do
+  @moduledoc false
   use Ecto.Repo,
     otp_app: :railway_ipc,
     adapter: Ecto.Adapters.Postgres

--- a/lib/railway_ipc/republish_command_consumer.ex
+++ b/lib/railway_ipc/republish_command_consumer.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.RepublishCommandConsumer do
+  @moduledoc false
   defmacro __using__(opts) do
     quote do
       require Logger

--- a/lib/railway_ipc/requests_consumer.ex
+++ b/lib/railway_ipc/requests_consumer.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.RequestsConsumer do
+  @moduledoc false
   defmacro __using__(opts) do
     quote do
       require Logger

--- a/lib/railway_ipc/stream_behaviour.ex
+++ b/lib/railway_ipc/stream_behaviour.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.StreamBehaviour do
+  @moduledoc false
   @callback connect :: {:ok, %{connection: map(), channel: map()}} | {:error, any()}
   @callback bind_queue(
               channel :: map(),

--- a/lib/railway_ipc/supervisor.ex
+++ b/lib/railway_ipc/supervisor.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Connection.Supervisor do
+  @moduledoc false
   use Supervisor
   alias RailwayIpc.Telemetry
 

--- a/lib/railway_ipc/utils.ex
+++ b/lib/railway_ipc/utils.ex
@@ -1,4 +1,6 @@
 defmodule RailwayIpc.Utils do
+  @moduledoc false
+
   def module_defined?(module) do
     try do
       # forces module to be loaded

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Factory do
+  @moduledoc false
   use ExMachina.Ecto, repo: RailwayIpc.Dev.Repo
   alias RailwayIpc.Persistence.{PublishedMessage, ConsumedMessage}
 

--- a/test/support/ipc/consumers/batch_commands_consumer.ex
+++ b/test/support/ipc/consumers/batch_commands_consumer.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Test.BatchCommandsConsumer do
+  @moduledoc false
   use RailwayIpc.CommandsConsumer,
     commands_exchange: "commands_exchange",
     events_exchange: "events_exchange",

--- a/test/support/ipc/consumers/batch_events_consumer.ex
+++ b/test/support/ipc/consumers/batch_events_consumer.ex
@@ -1,3 +1,4 @@
 defmodule RailwayIpc.Test.BatchEventsConsumer do
+  @moduledoc false
   use RailwayIpc.EventsConsumer, exchange: "experts", queue: "are_es_tee"
 end

--- a/test/support/ipc/consumers/batch_requests_consumer.ex
+++ b/test/support/ipc/consumers/batch_requests_consumer.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Test.BatchRequestsConsumer do
+  @moduledoc false
   use RailwayIpc.RequestsConsumer,
     exchange: "experts",
     queue: "are_es_tee"

--- a/test/support/ipc/consumers/error_consumer.ex
+++ b/test/support/ipc/consumers/error_consumer.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Test.ErrorConsumer do
+  @moduledoc false
   use RailwayIpc.CommandsConsumer,
     commands_exchange: "commands_exchange",
     events_exchange: "events_exchange",

--- a/test/support/ipc/consumers/okay_consumer.ex
+++ b/test/support/ipc/consumers/okay_consumer.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Test.OkayConsumer do
+  @moduledoc false
   use RailwayIpc.CommandsConsumer,
     commands_exchange: "commands_exchange",
     events_exchange: "events_exchange",

--- a/test/support/ipc/publishers/batch_events_publisher.ex
+++ b/test/support/ipc/publishers/batch_events_publisher.ex
@@ -1,4 +1,5 @@
 defmodule RailwayIpc.Test.BatchEventsPublisher do
+  @moduledoc false
   use RailwayIpc.Publisher, exchange: "batch:events"
 
   def emit(message) do


### PR DESCRIPTION
"Fixing" these credo warnings by defaulting moduledoc to "false". Not sure what all these modules do yet, but I _do_ want docs for them.  Setting them to a default does allows me to a) move further along cleaning up credo warnings so that we can run it for CI and b) have a reminder that docs need to be written once I know what the modules do.