### PR TITLE
Fix credo ParameterPatternMatching warning

### DIFF
--- a/lib/railway_ipc/commands_consumer.ex
+++ b/lib/railway_ipc/commands_consumer.ex
@@ -33,12 +33,12 @@ defmodule RailwayIpc.CommandsConsumer do
 
       def handle_info(
             {:basic_deliver, payload, %{delivery_tag: delivery_tag}},
-            state = %{
+            %{
               channel: channel,
               events_exchange: exchange,
               commands_exchange: commands_exchange,
               queue: queue
-            }
+            } = state
           ) do
         Logger.metadata(feature: "railway_ipc_commands_consumer")
 

--- a/lib/railway_ipc/connection.ex
+++ b/lib/railway_ipc/connection.ex
@@ -52,17 +52,17 @@ defmodule RailwayIpc.Connection do
     {:stop, :normal, state}
   end
 
-  def handle_call(:publisher_channel, _from, state = %{publisher_channel: channel}) do
+  def handle_call(:publisher_channel, _from, %{publisher_channel: channel} = state) do
     {:reply, channel, state}
   end
 
   def handle_call(
         {:consume, spec},
         _from,
-        state = %{
+        %{
           consumer_channels: channels,
           connection: connection
-        }
+        } = state
       ) do
     Telemetry.track_adding_consumer(
       %{spec: spec},

--- a/lib/railway_ipc/events_consumer.ex
+++ b/lib/railway_ipc/events_consumer.ex
@@ -32,7 +32,7 @@ defmodule RailwayIpc.EventsConsumer do
 
       def handle_info(
             {:basic_deliver, payload, %{delivery_tag: delivery_tag}},
-            state = %{channel: channel, exchange: exchange, queue: queue}
+            %{channel: channel, exchange: exchange, queue: queue} = state
           ) do
         Logger.metadata(feature: "railway_ipc_consumer")
 

--- a/lib/railway_ipc/republish_command_consumer.ex
+++ b/lib/railway_ipc/republish_command_consumer.ex
@@ -31,10 +31,10 @@ defmodule RailwayIpc.RepublishCommandConsumer do
 
       def handle_info(
             {:basic_deliver, payload, %{delivery_tag: delivery_tag}},
-            state = %{
+            %{
               channel: channel,
               queue: queue
-            }
+            } = state
           ) do
         ack_function = fn ->
           @stream_adapter.ack(channel, delivery_tag)

--- a/lib/railway_ipc/requests_consumer.ex
+++ b/lib/railway_ipc/requests_consumer.ex
@@ -32,7 +32,7 @@ defmodule RailwayIpc.RequestsConsumer do
 
       def handle_info(
             {:basic_deliver, payload, %{delivery_tag: delivery_tag}},
-            state = %{channel: channel, exchange: exchange, queue: queue}
+            %{channel: channel, exchange: exchange, queue: queue} = state
           ) do
         Logger.metadata(feature: "railway_ipc_request")
 


### PR DESCRIPTION
Ensure parameter name is after the value for consistency.