### PR TITLE
Fix Credo warnings

### DIFF
--- a/lib/railway_ipc/core/requests_consumer.ex
+++ b/lib/railway_ipc/core/requests_consumer.ex
@@ -1,8 +1,8 @@
 defmodule RailwayIpc.Core.RequestsConsumer do
   @moduledoc false
   require Logger
-  alias RailwayIpc.Telemetry
   alias RailwayIpc.Core.Payload
+  alias RailwayIpc.Telemetry
 
   def process(payload, module, ack_func, reply_func) do
     Telemetry.track_process_message(

--- a/lib/railway_ipc/events_consumer.ex
+++ b/lib/railway_ipc/events_consumer.ex
@@ -11,9 +11,9 @@ defmodule RailwayIpc.EventsConsumer do
                         RailwayIpc.RabbitMQ.RabbitMQAdapter
                       )
 
-      alias RailwayIpc.Telemetry
       alias RailwayIpc.Connection, as: Connection
       alias RailwayIpc.Core.EventsConsumer
+      alias RailwayIpc.Telemetry
 
       def start_link(_state) do
         exchange = Keyword.get(unquote(opts), :exchange)

--- a/lib/railway_ipc/ipc/consumers/republished_messages_consumer.ex
+++ b/lib/railway_ipc/ipc/consumers/republished_messages_consumer.ex
@@ -3,8 +3,8 @@ defmodule RailwayIpc.Ipc.RepublishedMessagesConsumer do
   use RailwayIpc.RepublishCommandConsumer,
     queue: "railway_ipc:republished_messages:commands"
 
-  alias RailwayIpc.Ipc.Logger
   alias RailwayIpc.Commands.RepublishMessage
+  alias RailwayIpc.Ipc.Logger
   alias RailwayIpc.PublishedMessage
 
   def handle_in(

--- a/lib/railway_ipc/ipc/publishers/republished_messages_publisher.ex
+++ b/lib/railway_ipc/ipc/publishers/republished_messages_publisher.ex
@@ -3,8 +3,8 @@ defmodule RailwayIpc.Ipc.RepublishedMessagesPublisher do
   use RailwayIpc.Publisher,
     queue: "railway_ipc:republished_messages:commands"
 
-  alias RailwayIpc.Ipc.RepublishedMessageAdapter, as: DataAdapter
   alias RailwayIpc.Ipc.Logger, as: IpcLogger
+  alias RailwayIpc.Ipc.RepublishedMessageAdapter, as: DataAdapter
   require Logger
 
   def invoke_republish_message(

--- a/lib/railway_ipc/message_consumption.ex
+++ b/lib/railway_ipc/message_consumption.ex
@@ -1,9 +1,9 @@
 defmodule RailwayIpc.MessageConsumption do
   @moduledoc false
-  alias RailwayIpc.Core.{CommandMessage, EventMessage}
-  alias RailwayIpc.Core.MessageConsumptionResult, as: Result
   alias RailwayIpc.CommandMessageHandler
   alias RailwayIpc.ConsumedMessage, as: ConsumedMessageContext
+  alias RailwayIpc.Core.MessageConsumptionResult, as: Result
+  alias RailwayIpc.Core.{CommandMessage, EventMessage}
   alias RailwayIpc.Telemetry
 
   @repo Application.get_env(:railway_ipc, :repo, RailwayIpc.Dev.Repo)

--- a/lib/railway_ipc/message_consumption_behaviour.ex
+++ b/lib/railway_ipc/message_consumption_behaviour.ex
@@ -1,6 +1,6 @@
 defmodule RailwayIpc.MessageConsumptionBehaviour do
   @moduledoc false
-  alias RailwayIpc.Core.{EventMessage, CommandMessage}
+  alias RailwayIpc.Core.{CommandMessage, EventMessage}
 
   @callback process(String.t(), String.t(), String.t(), String.t(), EventMessage) ::
               tuple()

--- a/lib/railway_ipc/message_publishing.ex
+++ b/lib/railway_ipc/message_publishing.ex
@@ -1,6 +1,6 @@
 defmodule RailwayIpc.MessagePublishing do
   @moduledoc false
-  alias RailwayIpc.Core.{RoutingInfo, PublishedMessage}
+  alias RailwayIpc.Core.{PublishedMessage, RoutingInfo}
   alias RailwayIpc.PublishedMessage, as: PublishedMessageContext
   @behaviour RailwayIpc.MessagePublishingBehaviour
 

--- a/lib/railway_ipc/persistence.ex
+++ b/lib/railway_ipc/persistence.ex
@@ -3,9 +3,9 @@ defmodule RailwayIpc.Persistence do
   @behaviour RailwayIpc.PersistenceBehaviour
   @repo Application.get_env(:railway_ipc, :repo, RailwayIpc.Dev.Repo)
   alias RailwayIpc.Persistence.{
-    PublishedMessage,
     ConsumedMessage,
     ConsumedMessageAdapter,
+    PublishedMessage,
     PublishedMessageAdapter
   }
 

--- a/lib/railway_ipc/requests_consumer.ex
+++ b/lib/railway_ipc/requests_consumer.ex
@@ -11,9 +11,9 @@ defmodule RailwayIpc.RequestsConsumer do
                         RailwayIpc.RabbitMQ.RabbitMQAdapter
                       )
 
-      alias RailwayIpc.Telemetry
       alias RailwayIpc.Connection, as: Connection
       alias RailwayIpc.Core.RequestsConsumer
+      alias RailwayIpc.Telemetry
 
       def start_link(_state) do
         exchange = Keyword.get(unquote(opts), :exchange)

--- a/test/railway_ipc/commands_consumer_test.exs
+++ b/test/railway_ipc/commands_consumer_test.exs
@@ -5,10 +5,10 @@ defmodule RailwayIpc.CommandsConsumerTest do
   setup :set_mox_global
   setup :verify_on_exit!
 
-  alias RailwayIpc.Test.BatchCommandsConsumer
   alias RailwayIpc.Connection
-  alias RailwayIpc.StreamMock
   alias RailwayIpc.Core.Payload
+  alias RailwayIpc.StreamMock
+  alias RailwayIpc.Test.BatchCommandsConsumer
 
   setup do
     StreamMock

--- a/test/railway_ipc/consumed_message_test.exs
+++ b/test/railway_ipc/consumed_message_test.exs
@@ -4,9 +4,9 @@ defmodule RailwayIpc.ConsumedMessageTest do
 
   import RailwayIpc.Factory
   use RailwayIpc.DataCase
-  alias RailwayIpc.{MessageConsumption, ConsumedMessage}
-  alias RailwayIpc.Test.BatchEventsConsumer
   alias RailwayIpc.Core.{EventMessage, Payload}
+  alias RailwayIpc.Test.BatchEventsConsumer
+  alias RailwayIpc.{ConsumedMessage, MessageConsumption}
   @tag capture_log: true
 
   setup do

--- a/test/railway_ipc/core/requests_consumer_test.exs
+++ b/test/railway_ipc/core/requests_consumer_test.exs
@@ -1,7 +1,7 @@
 defmodule RailwayIpc.Core.RequestsConsumerTest do
   use ExUnit.Case
-  alias RailwayIpc.Core.RequestsConsumer
   alias RailwayIpc.Core.Payload
+  alias RailwayIpc.Core.RequestsConsumer
 
   test "acks and replies when reply tuple returned" do
     {:ok, request} =

--- a/test/railway_ipc/events_consumer_test.exs
+++ b/test/railway_ipc/events_consumer_test.exs
@@ -4,11 +4,11 @@ defmodule RailwayIpc.EventsConsumerTest do
   setup :set_mox_global
   setup :verify_on_exit!
 
-  alias RailwayIpc.Test.BatchEventsConsumer
   alias RailwayIpc.Connection
-  alias RailwayIpc.StreamMock
   alias RailwayIpc.Core.Payload
   alias RailwayIpc.MessageConsumption
+  alias RailwayIpc.StreamMock
+  alias RailwayIpc.Test.BatchEventsConsumer
 
   setup do
     StreamMock

--- a/test/railway_ipc/ipc/publishers/republished_messages_pubisher_test.exs
+++ b/test/railway_ipc/ipc/publishers/republished_messages_pubisher_test.exs
@@ -5,9 +5,9 @@ defmodule RailwayIpc.Ipc.RepublishedMessagesPublisherTest do
   setup :set_mox_global
   setup :verify_on_exit!
 
-  alias RailwayIpc.{StreamMock, Connection, MessagePublishing}
   alias RailwayIpc.Core.{Payload, RoutingInfo}
   alias RailwayIpc.Ipc.RepublishedMessagesPublisher
+  alias RailwayIpc.{Connection, MessagePublishing, StreamMock}
   @queue "railway_ipc:republished_messages:commands"
 
   setup do

--- a/test/railway_ipc/message_consumption_test.exs
+++ b/test/railway_ipc/message_consumption_test.exs
@@ -7,14 +7,14 @@ defmodule RailwayIpc.MessageConsumptionTest do
   import Mox
   import RailwayIpc.Factory
 
-  alias RailwayIpc.MessageConsumption
-  alias RailwayIpc.Core.Payload
-  alias RailwayIpc.Test.BatchCommandsConsumer
-  alias RailwayIpc.Test.OkayConsumer
-  alias RailwayIpc.Test.ErrorConsumer
   alias RailwayIpc.Core.CommandMessage
   alias RailwayIpc.Core.EventMessage
+  alias RailwayIpc.Core.Payload
+  alias RailwayIpc.MessageConsumption
   alias RailwayIpc.Persistence.ConsumedMessage
+  alias RailwayIpc.Test.BatchCommandsConsumer
+  alias RailwayIpc.Test.ErrorConsumer
+  alias RailwayIpc.Test.OkayConsumer
 
   setup :verify_on_exit!
 

--- a/test/railway_ipc/message_publishing_test.exs
+++ b/test/railway_ipc/message_publishing_test.exs
@@ -4,9 +4,9 @@ defmodule RailwayIpc.MessagePublishingTest do
   use ExUnit.Case
   import Mox
   import RailwayIpc.Factory
-  alias RailwayIpc.Persistence.PublishedMessage
-  alias RailwayIpc.MessagePublishing
   alias RailwayIpc.Core.RoutingInfo
+  alias RailwayIpc.MessagePublishing
+  alias RailwayIpc.Persistence.PublishedMessage
   setup :verify_on_exit!
 
   describe "process/2" do

--- a/test/railway_ipc/persistence/published_message_adapter_test.exs
+++ b/test/railway_ipc/persistence/published_message_adapter_test.exs
@@ -1,7 +1,7 @@
 defmodule RailwayIpc.Persistence.PublishedMessageAdapterTest do
   use ExUnit.Case
-  alias RailwayIpc.MessagePublishing
   alias RailwayIpc.Core.RoutingInfo
+  alias RailwayIpc.MessagePublishing
   alias RailwayIpc.Persistence.PublishedMessageAdapter
 
   describe "to_persistence/1" do

--- a/test/railway_ipc/persistence_test.exs
+++ b/test/railway_ipc/persistence_test.exs
@@ -2,8 +2,8 @@ defmodule RailwayIpc.PersistenceTest do
   use ExUnit.Case
   use RailwayIpc.DataCase
 
-  alias RailwayIpc.{Persistence, MessageConsumption, MessagePublishing}
   alias RailwayIpc.Core.{CommandMessage, Payload, RoutingInfo}
+  alias RailwayIpc.{MessageConsumption, MessagePublishing, Persistence}
 
   @tag capture_log: true
   describe "insert_published_message/3" do

--- a/test/railway_ipc/published_message_test.exs
+++ b/test/railway_ipc/published_message_test.exs
@@ -4,8 +4,8 @@ defmodule RailwayIpc.PublishedMessageTest do
 
   import RailwayIpc.Factory
   use RailwayIpc.DataCase
-  alias RailwayIpc.MessagePublishing
   alias RailwayIpc.Core.RoutingInfo
+  alias RailwayIpc.MessagePublishing
   @tag capture_log: true
 
   setup do

--- a/test/railway_ipc/publisher_test.exs
+++ b/test/railway_ipc/publisher_test.exs
@@ -5,9 +5,9 @@ defmodule RailwayIpc.PublisherTest do
   setup :set_mox_global
   setup :verify_on_exit!
 
-  alias RailwayIpc.{StreamMock, Connection, MessagePublishing}
   alias RailwayIpc.Core.Payload
   alias RailwayIpc.Test.BatchEventsPublisher
+  alias RailwayIpc.{Connection, MessagePublishing, StreamMock}
 
   setup do
     StreamMock

--- a/test/railway_ipc/railway_ipc_test.exs
+++ b/test/railway_ipc/railway_ipc_test.exs
@@ -6,7 +6,7 @@ defmodule RailwayIpcTest do
   import Mox
   import RailwayIpc.Factory
 
-  alias RailwayIpc.{StreamMock, Connection, MessagePublishing, Persistence}
+  alias RailwayIpc.{Connection, MessagePublishing, Persistence, StreamMock}
 
   setup :set_mox_global
   setup :verify_on_exit!

--- a/test/railway_ipc/requests_consumer_test.exs
+++ b/test/railway_ipc/requests_consumer_test.exs
@@ -4,10 +4,10 @@ defmodule RailwayIpc.RequestsConsumerTest do
   setup :set_mox_global
   setup :verify_on_exit!
 
-  alias RailwayIpc.Test.BatchRequestsConsumer
   alias RailwayIpc.Connection
-  alias RailwayIpc.StreamMock
   alias RailwayIpc.Core.Payload
+  alias RailwayIpc.StreamMock
+  alias RailwayIpc.Test.BatchRequestsConsumer
 
   setup do
     StreamMock

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,7 +1,7 @@
 defmodule RailwayIpc.Factory do
   @moduledoc false
   use ExMachina.Ecto, repo: RailwayIpc.Dev.Repo
-  alias RailwayIpc.Persistence.{PublishedMessage, ConsumedMessage}
+  alias RailwayIpc.Persistence.{ConsumedMessage, PublishedMessage}
 
   def published_message_factory do
     uuid = Ecto.UUID.generate()


### PR DESCRIPTION
Credo expects aliases to be in alphabetical order.