### PR TITLE
Ignore AliasUsage in tests

### DIFF
--- a/test/railway_ipc/ipc/consumers/republished_messages_consumer_test.exs
+++ b/test/railway_ipc/ipc/consumers/republished_messages_consumer_test.exs
@@ -11,6 +11,8 @@ defmodule RailwayIpc.Ipc.RebublishedMessagesConsumerTest do
     setup do
       persisted_message = build(:published_message)
       uuid = persisted_message.uuid
+
+      # credo:disable-for-lines:2 Credo.Check.Design.AliasUsage
       data = RailwayIpc.Commands.RepublishMessage.Data.new(published_message_uuid: uuid)
       command = RailwayIpc.Commands.RepublishMessage.new(data: data)
       [persisted_message: persisted_message, uuid: uuid, command: command]
@@ -68,6 +70,8 @@ defmodule RailwayIpc.Ipc.RebublishedMessagesConsumerTest do
 
     test "it returns an error tuple when the persisted published message UUID is invalid" do
       uuid = "12345"
+
+      # credo:disable-for-lines:2 Credo.Check.Design.AliasUsage
       data = RailwayIpc.Commands.RepublishMessage.Data.new(published_message_uuid: uuid)
       command = RailwayIpc.Commands.RepublishMessage.new(data: data)
 

--- a/test/railway_ipc/ipc/publishers/republished_messages_pubisher_test.exs
+++ b/test/railway_ipc/ipc/publishers/republished_messages_pubisher_test.exs
@@ -65,6 +65,7 @@ defmodule RailwayIpc.Ipc.RepublishedMessagesPublisherTest do
       original_published_message_uuid: original_published_message_uuid
     } do
       command =
+        # credo:disable-for-next-line Credo.Check.Design.AliasUsage
         RailwayIpc.Commands.RepublishMessage.new(user_uuid: "abcabc", uuid: Ecto.UUID.generate())
 
       persisted_published_message =
@@ -94,6 +95,7 @@ defmodule RailwayIpc.Ipc.RepublishedMessagesPublisherTest do
       original_published_message_uuid: original_published_message_uuid
     } do
       command =
+        # credo:disable-for-next-line Credo.Check.Design.AliasUsage
         RailwayIpc.Commands.RepublishMessage.new(user_uuid: "abcabc", uuid: Ecto.UUID.generate())
 
       persisted_published_message =

--- a/test/railway_ipc/publisher_test.exs
+++ b/test/railway_ipc/publisher_test.exs
@@ -206,6 +206,7 @@ defmodule RailwayIpc.PublisherTest do
 
     test "it adds a uuid to the message" do
       message =
+        # credo:disable-for-next-line Credo.Check.Design.AliasUsage
         RailwayIpc.Commands.RepublishMessage.new(%{
           user_uuid: Ecto.UUID.generate()
         })
@@ -229,6 +230,7 @@ defmodule RailwayIpc.PublisherTest do
       message_uuid = Ecto.UUID.generate()
 
       message =
+        # credo:disable-for-next-line Credo.Check.Design.AliasUsage
         RailwayIpc.Commands.RepublishMessage.new(%{
           user_uuid: Ecto.UUID.generate(),
           uuid: message_uuid
@@ -255,6 +257,7 @@ defmodule RailwayIpc.PublisherTest do
       queue = "republish_queue"
 
       message =
+        # credo:disable-for-next-line Credo.Check.Design.AliasUsage
         RailwayIpc.Commands.RepublishMessage.new(%{
           user_uuid: user_uuid,
           correlation_id: correlation_id,
@@ -280,6 +283,7 @@ defmodule RailwayIpc.PublisherTest do
       queue = "republish_queue"
 
       message =
+        # credo:disable-for-next-line Credo.Check.Design.AliasUsage
         RailwayIpc.Commands.RepublishMessage.new(%{
           user_uuid: user_uuid,
           correlation_id: correlation_id,

--- a/test/railway_ipc/republish_command_consumer_test.exs
+++ b/test/railway_ipc/republish_command_consumer_test.exs
@@ -60,11 +60,13 @@ defmodule RailwayIpc.RepublishedMessagesConsumerTest do
 
   test "acks message when successful", %{persisted_published_message: persisted_published_message} do
     data =
+      # credo:disable-for-next-line Credo.Check.Design.AliasUsage
       RailwayIpc.Commands.RepublishMessage.Data.new(
         published_message_uuid: persisted_published_message.uuid
       )
 
     {:ok, command} =
+      # credo:disable-for-next-line Credo.Check.Design.AliasUsage
       RailwayIpc.Commands.RepublishMessage.new(correlation_id: "123", data: data)
       |> Payload.encode()
 

--- a/test/railway_ipc/utils_test.exs
+++ b/test/railway_ipc/utils_test.exs
@@ -21,12 +21,15 @@ defmodule RailwayIpc.UtilsTest do
       correlation_id = "correlation_id"
       context = %{"context" => "data"}
 
+      # credo:disable-for-next-line Credo.Check.Design.AliasUsage
+      data = Events.AThingWasDone.Data.new(value: "Something useful")
+
       assert Events.AThingWasDone.new(
                uuid: uuid,
                user_uuid: user_uuid,
                correlation_id: correlation_id,
                context: context,
-               data: Events.AThingWasDone.Data.new(value: "Something useful")
+               data: data
              )
              |> Utils.protobuf_to_json() ==
                "{\"data\":{\"context\":{\"context\":\"data\"},\"correlationId\":\"correlation_id\",\"data\":{\"data\":{\"value\":\"Something useful\"},\"type\":\"Events.AThingWasDone.Data\"},\"userUuid\":\"user_uuid\",\"uuid\":\"uuid\"},\"type\":\"Events.AThingWasDone\"}"

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -26,9 +26,11 @@ defmodule RailwayIpc.DataCase do
   end
 
   setup tags do
+    # credo:disable-for-next-line Credo.Check.Design.AliasUsage
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(RailwayIpc.Dev.Repo)
 
     unless tags[:async] do
+      # credo:disable-for-next-line Credo.Check.Design.AliasUsage
       Ecto.Adapters.SQL.Sandbox.mode(RailwayIpc.Dev.Repo, {:shared, self()})
     end
 


### PR DESCRIPTION
Have Credo ignore AliasUsage warnings (mostly in tests)