### PR TITLE
End to end / smoke tests

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -2,9 +2,18 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-echo "Checking formatting..."
+echo
+echo "> Checking formatting..."
 mix format --check-formatted
-echo "Linting..."
+
+echo
+echo "> Linting..."
 mix credo
-echo "Running tests..."
+
+echo
+echo "> Running tests..."
 mix test
+
+echo
+echo "> Running end to end tests..."
+MIX_ENV=e2e mix test --only e2e

--- a/config/e2e.exs
+++ b/config/e2e.exs
@@ -1,0 +1,14 @@
+use Mix.Config
+
+config :railway_ipc,
+  ecto_repos: [RailwayIpc.Dev.Repo]
+
+config :logger, level: :info
+
+config :railway_ipc, RailwayIpc.Dev.Repo,
+  username: "postgres",
+  password: "postgres",
+  database: "railway_ipc_test",
+  show_sensitive_data_on_connection_error: true,
+  pool_size: 10,
+  pool: Ecto.Adapters.SQL.Sandbox

--- a/lib/railway_ipc/application.ex
+++ b/lib/railway_ipc/application.ex
@@ -40,6 +40,13 @@ defmodule RailwayIpc.Application do
     ]
   end
 
+  def children(true, true, :e2e) do
+    [
+      @repo,
+      {RailwayIpc.Connection.Supervisor, []}
+    ]
+  end
+
   def children(_, _, _), do: []
 
   defp attach_publisher_loggers do

--- a/mix.exs
+++ b/mix.exs
@@ -31,11 +31,11 @@ defmodule RailwayIpc.MixProject do
       {:ecto_sql, "~> 3.0"},
       {:elixir_uuid, "~> 1.2"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-      {:ex_machina, "~> 2.3", only: :test},
+      {:ex_machina, "~> 2.3", only: [:test, :e2e]},
       {:google_protos, "~> 0.1"},
       {:jason, "~> 1.1"},
       {:mix_test_watch, "~> 0.8", only: :dev, runtime: false},
-      {:mox, "~> 0.5", only: :test},
+      {:mox, "~> 0.5", only: [:test, :e2e]},
       {:postgrex, ">= 0.0.0"},
       {:protobuf, "~> 0.5.3"},
       {:telemetry, "~> 0.4"}
@@ -48,6 +48,7 @@ defmodule RailwayIpc.MixProject do
     ]
   end
 
+  defp elixirc_paths(:e2e), do: ["test/support", "lib"]
   defp elixirc_paths(:test), do: ["test/support", "lib"]
   defp elixirc_paths(_), do: ["lib", "priv"]
 

--- a/test/e2e/consumer_test.exs
+++ b/test/e2e/consumer_test.exs
@@ -1,0 +1,91 @@
+defmodule E2E.ConsumerTest do
+  # Note that we need to use async: false since tests interact
+  # with external Rabbit exchanges, queues, etc.
+  use ExUnit.Case, async: false
+  use RailwayIpc.DataCase
+  use Test.Support.RabbitCase
+
+  alias Events.AThingWasDone, as: Proto
+  alias RailwayIpc.Connection
+  alias Test.Support.Helpers
+
+  @timeout _up_to_thirty_seconds = 30_000
+
+  defmodule Subject do
+    use RailwayIpc.EventsConsumer,
+      exchange: "railway:test",
+      queue: "railway:test:events"
+
+    def handle_in(_payload) do
+      :ok
+    end
+  end
+
+  setup_all do
+    {:ok, connection} = open_connection("amqp://guest:guest@localhost:5672")
+
+    # Publishers don't know about queues, only exchanges. If we send a
+    # message to an exchange that doesn't have a queue bound to it, the
+    # message will be lost. In production, this isn't an issue since
+    # consumers will take care of the binding. However, in the test env
+    # we have to setup the queue ourselves since sometimes a consumer is
+    # not set up, otherwise the test message will be lost.
+    create_and_bind_queue(connection, "railway:test:events", "railway:test")
+
+    pid =
+      start_supervised!(%{
+        id: RailwayIpc.Connection,
+        start: {RailwayIpc.Connection, :start_link, []}
+      })
+
+    exit_fn = fn ->
+      delete_queue(connection, "railway:test:events")
+      delete_exchange(connection, "railway:test")
+      close_connection(connection)
+    end
+
+    on_exit(exit_fn)
+    %{connection: connection, pid: pid}
+  end
+
+  setup context do
+    exit_fn = fn ->
+      purge_queue(context.connection, "railway:test:events")
+    end
+
+    on_exit(exit_fn)
+  end
+
+  @tag :e2e
+  test "successfully consume a message", context do
+    # Make sure the queue is empty
+    Helpers.wait_for_true(@timeout, fn ->
+      assert 0 == queue_count("railway:test:events")
+    end)
+
+    # Publish a message
+    channel = Connection.publisher_channel(context.pid)
+    proto = Proto.new(uuid: UUID.uuid4())
+    :ok = RailwayIpc.Publisher.publish(channel, "railway:test", proto)
+
+    # Make sure it arrived in the queue
+    Helpers.wait_for_true(@timeout, fn ->
+      assert 1 == queue_count("railway:test:events")
+    end)
+
+    # Get the current message count
+    count_before = row_count("railway_ipc_consumed_messages")
+
+    # Start the consumer
+    start_supervised!(%{id: Subject, start: {Subject, :start_link, [:ok]}})
+
+    # Assert the consumer processed the message
+    Helpers.wait_for_true(@timeout, fn ->
+      assert 0 == queue_count("railway:test:events")
+    end)
+
+    # Make sure the message was persisted
+    count_after = row_count("railway_ipc_consumed_messages")
+    assert 1 == count_after - count_before
+  end
+end

--- a/test/e2e/publisher_test.exs
+++ b/test/e2e/publisher_test.exs
@@ -1,0 +1,70 @@
+defmodule E2E.PublisherTest do
+  # Note that we need to use async: false since tests interact
+  # with external Rabbit exchanges, queues, etc.
+  use ExUnit.Case, async: false
+  use RailwayIpc.DataCase
+  use Test.Support.RabbitCase
+
+  alias Events.AThingWasDone, as: Proto
+  alias RailwayIpc.Connection
+  alias Test.Support.Helpers
+
+  @timeout _up_to_thirty_seconds = 30_000
+
+  setup_all do
+    {:ok, connection} = open_connection("amqp://guest:guest@localhost:5672")
+
+    # Publishers don't know about queues, only exchanges. If we send a
+    # message to an exchange that doesn't have a queue bound to it, the
+    # message will be lost. In production, this isn't an issue since
+    # consumers will take care of the binding. However, in the test env
+    # we have to setup the queue ourselves since sometimes a consumer is
+    # not set up, otherwise the test message will be lost.
+    create_and_bind_queue(connection, "railway:test:events", "railway:test")
+
+    pid = start_supervised!(%{id: Connection, start: {Connection, :start_link, []}})
+
+    exit_fn = fn ->
+      delete_queue(connection, "railway:test:events")
+      delete_exchange(connection, "railway:test")
+      close_connection(connection)
+    end
+
+    on_exit(exit_fn)
+    %{connection: connection, pid: pid}
+  end
+
+  setup context do
+    exit_fn = fn ->
+      purge_queue(context.connection, "railway:test:events")
+    end
+
+    on_exit(exit_fn)
+  end
+
+  @tag :e2e
+  test "successfully publish a message", context do
+    # Make sure the queue is empty
+    Helpers.wait_for_true(@timeout, fn ->
+      assert 0 == queue_count("railway:test:events")
+    end)
+
+    # Get the current message count
+    count_before = row_count("railway_ipc_published_messages")
+
+    # Publish a message; this doesn't go through the macro - might want to
+    # do that, haven't decided
+    channel = Connection.publisher_channel(context.pid)
+    proto = Proto.new(uuid: UUID.uuid4())
+    :ok = RailwayIpc.Publisher.publish(channel, "railway:test", proto)
+
+    # Make sure it arrived in the queue
+    Helpers.wait_for_true(@timeout, fn ->
+      assert 1 == queue_count("railway:test:events")
+    end)
+
+    # Make sure the message was persisted
+    count_after = row_count("railway_ipc_published_messages")
+    assert 1 == count_after - count_before
+  end
+end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -14,6 +14,8 @@ defmodule RailwayIpc.DataCase do
 
   use ExUnit.CaseTemplate
 
+  alias RailwayIpc.Dev.Repo
+
   using do
     quote do
       alias RailwayIpc.Dev.Repo
@@ -51,5 +53,16 @@ defmodule RailwayIpc.DataCase do
         opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
       end)
     end)
+  end
+
+  @doc """
+  Retrieves the current row count for the given table. Since SQL `count`
+  requires a column, we have to provide that as well. This defaults the
+  column name to UUID since all Railway tables have it, but you can override
+  it if you want.
+
+  """
+  def row_count(table, column \\ :uuid) do
+    Repo.aggregate(table, :count, column)
   end
 end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -1,0 +1,32 @@
+defmodule Test.Support.Helpers do
+  @moduledoc """
+  Various test helpers.
+
+  """
+
+  @doc """
+  Repeatedly executes `fun` until it either returns `true` or
+  reaches `timeout`.
+
+  ## Example
+
+  In a test, publish a message to a queue, then wait until it arrives in
+  the queue. Fail if the message hasn't arrived after two seconds.
+
+  ```
+  wait_for_true(_2_seconds = 2000, fn ->
+    assert 1 == queue_count("example_queue")
+  end)
+  ```
+
+  """
+  def wait_for_true(timeout, fun) when timeout > 0 do
+    fun.()
+  rescue
+    _ ->
+      Process.sleep(100)
+      wait_for_true(timeout - 100, fun)
+  end
+
+  def wait_for_true(_timeout, fun), do: fun.()
+end

--- a/test/support/rabbit_case.ex
+++ b/test/support/rabbit_case.ex
@@ -1,0 +1,157 @@
+defmodule Test.Support.RabbitCase do
+  @moduledoc """
+  Test helpers for dealing with RabbitMQ.
+
+  """
+
+  defmacro __using__([]) do
+    quote do
+      use AMQP
+
+      @doc """
+      Opens a new RabbitMQ connection.
+
+      """
+      def open_connection(uri) do
+        AMQP.Connection.open(uri)
+      end
+
+      @doc """
+      Closes a RabbitMQ connection.
+
+      """
+      def close_connection(connection) do
+        AMQP.Connection.close(connection)
+      end
+
+      @doc """
+      Open a RabbitMQ channel.
+
+      """
+      def open_channel(connection) do
+        AMQP.Channel.open(connection)
+      end
+
+      @doc """
+      Close a RabbitMQ channel.
+
+      """
+      def close_channel(channel) do
+        AMQP.Channel.close(channel)
+      end
+
+      @doc """
+      Delete the specified exchange and all bindings to it.
+
+      """
+      def delete_exchange(connection, exchange) do
+        {:ok, channel} = AMQP.Channel.open(connection)
+        AMQP.Exchange.delete(channel, exchange)
+        AMQP.Channel.close(channel)
+      end
+
+      @doc """
+      Creates an exchange, a queue, and binds them. The exchange may or may
+      not already exist; if it does a new one won't be created. This will
+      throw an error if the queue already exists, however (maybe? double
+      check that part about the queue is true).
+
+      """
+      def create_and_bind_queue(connection, queue, exchange) do
+        {:ok, channel} = AMQP.Channel.open(connection)
+        AMQP.Exchange.fanout(channel, exchange, options())
+        AMQP.Queue.declare(channel, queue, options())
+        AMQP.Queue.bind(channel, queue, exchange)
+        AMQP.Channel.close(channel)
+      end
+
+      @doc """
+      Delete the specified queue.
+
+      """
+      def delete_queue(connection, queue) do
+        {:ok, channel} = AMQP.Channel.open(connection)
+        AMQP.Queue.delete(channel, queue)
+        AMQP.Channel.close(channel)
+      end
+
+      @doc """
+      Purges all message from the given queue.
+
+      """
+      def purge_queue(connection, queue) do
+        {:ok, channel} = AMQP.Channel.open(connection)
+        AMQP.Queue.purge(channel, queue)
+        AMQP.Channel.close(channel)
+      catch
+        :exit, _ ->
+          :ok
+      end
+
+      @doc """
+      Publish a message. Expects message to be already encoded.
+
+      """
+      def publish_message(connection, exchange, message, routing_key \\ "") do
+        {:ok, channel} = AMQP.Channel.open(connection)
+        AMQP.Exchange.fanout(channel, exchange, options())
+        AMQP.Basic.publish(channel, exchange, routing_key, message)
+        AMQP.Channel.close(channel)
+      end
+
+      @doc """
+      Get the number of messages in the given queue.
+
+      """
+      def queue_count(queue) do
+        %{messages: message_count} = get_queue_info(queue)
+        message_count
+      end
+
+      @doc """
+      Retrieve information about the given queue using the Rabbit API.
+
+      """
+      def get_queue_info(queue_name) do
+        results = make_api_request(:queues)
+        Enum.find(results, fn q -> queue_name == q.name end)
+      end
+
+      @doc """
+      Retrieve information about the given exchange using the Rabbit API.
+
+      """
+      def get_exchange_info(exchange_name) do
+        results = make_api_request(:exchanges)
+        Enum.find(results, fn q -> exchange_name == q.name end)
+      end
+
+      @doc """
+      Retrieve information about the binding between the given queue and
+      exchange. Returns nil if no binding can be found.
+
+      """
+      def get_binding_info(exchange_name, queue_name) do
+        finder = fn binding ->
+          exchange_name == binding.source and queue_name == binding.destination
+        end
+
+        results = make_api_request(:bindings)
+        Enum.find(results, finder)
+      end
+
+      defp make_api_request(resource) do
+        url = "http://guest:guest@localhost:15672/api/#{resource}"
+        {:ok, {_, _, resp}} = :httpc.request(String.to_charlist(url))
+        Jason.decode!(resp, keys: :atoms)
+      end
+
+      defp options do
+        [
+          durable: true,
+          arguments: [{"x-dead-letter-exchange", :longstr, "lightrail:errors"}]
+        ]
+      end
+    end
+  end
+end

--- a/test/support/rabbit_case.ex
+++ b/test/support/rabbit_case.ex
@@ -148,8 +148,7 @@ defmodule Test.Support.RabbitCase do
 
       defp options do
         [
-          durable: true,
-          arguments: [{"x-dead-letter-exchange", :longstr, "lightrail:errors"}]
+          durable: true
         ]
       end
     end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,5 +4,14 @@ for app <- Application.spec(:railway_ipc, :applications) do
   Application.ensure_all_started(app)
 end
 
+# End to end integration tests are slow and require a running RabbitMQ
+# instance so don't run them by default. You can run them using
+#
+# `MIX_ENV=e2e mix test --only e2e`.
+#
+# Notice that you must specify the mix environment as `e2e` so that
+# we don't enable Mox.
+# End to end tests will always be ran in CI.
+ExUnit.configure(exclude: [e2e: true])
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(RailwayIpc.Dev.Repo, :manual)


### PR DESCRIPTION
All this mocking without at least a couple of end to end "happy path" tests makes be nervous. This sets up the infrastructure necessary to do end to end testing. It's a little complicated due to how Mox works (eventually, I'd like to get rid of Mox) because we have to use a separate `MIX_ENV`. Since e2e tests will be slower than the mocked tests, we'll run them separately using tags. They also won't be run by the default `mix test` task. You can run them explicitly using the command `MIX_ENV=e2e mix test --only e2e`. CircleCI will run the e2e tests as a last step.

Right now there are two end to end tests, one for publishing a message and another for consuming a message.

This also includes some test helpers for dealing with RabbitMQ, Ecto and a better mechanism for waiting for something to happen in a test than a plain, heavy-handed `Process.sleep`.