### PR TITLE
Refactor: No need to pass message module anymore

### DIFF
--- a/lib/railway_ipc/core/events_consumer.ex
+++ b/lib/railway_ipc/core/events_consumer.ex
@@ -1,7 +1,6 @@
 defmodule RailwayIpc.Core.EventsConsumer do
   @moduledoc false
   require Logger
-  alias RailwayIpc.Core.EventMessage
   alias RailwayIpc.Telemetry
 
   @message_consumption Application.get_env(
@@ -14,7 +13,7 @@ defmodule RailwayIpc.Core.EventsConsumer do
     Telemetry.track_process_message(
       %{payload: payload, module: module, exchange: exchange, queue: queue},
       fn ->
-        result = @message_consumption.process(payload, module, exchange, queue, EventMessage)
+        result = @message_consumption.process(payload, module, exchange, queue)
         {result |> post_processing(ack_func), %{result: result}}
       end
     )

--- a/lib/railway_ipc/message_consumption_behaviour.ex
+++ b/lib/railway_ipc/message_consumption_behaviour.ex
@@ -1,6 +1,5 @@
 defmodule RailwayIpc.MessageConsumptionBehaviour do
   @moduledoc false
-  alias RailwayIpc.Core.EventMessage
 
-  @callback process(String.t(), String.t(), String.t(), String.t(), EventMessage) :: tuple()
+  @callback process(String.t(), String.t(), String.t(), String.t()) :: tuple()
 end

--- a/test/railway_ipc/core/events_consumer_test.exs
+++ b/test/railway_ipc/core/events_consumer_test.exs
@@ -15,10 +15,9 @@ defmodule RailwayIpc.Core.EventsConsumerTest do
     queue = "queue"
 
     handle_module = __MODULE__
-    message_module = RailwayIpc.Core.EventMessage
 
     RailwayIpc.MessageConsumptionMock
-    |> expect(:process, fn ^payload, ^handle_module, ^exchange, ^queue, ^message_module ->
+    |> expect(:process, fn ^payload, ^handle_module, ^exchange, ^queue ->
       {:ok,
        %RailwayIpc.MessageConsumption{
          inbound_message: %{decoded_message: %Events.AThingWasDone{}}
@@ -46,10 +45,9 @@ defmodule RailwayIpc.Core.EventsConsumerTest do
     queue = "queue"
 
     handle_module = __MODULE__
-    message_module = RailwayIpc.Core.EventMessage
 
     RailwayIpc.MessageConsumptionMock
-    |> expect(:process, fn ^payload, ^handle_module, ^exchange, ^queue, ^message_module ->
+    |> expect(:process, fn ^payload, ^handle_module, ^exchange, ^queue ->
       {:error,
        %RailwayIpc.MessageConsumption{result: %{status: :error, reason: "Message type not found"}}}
     end)
@@ -75,10 +73,9 @@ defmodule RailwayIpc.Core.EventsConsumerTest do
     queue = "queue"
 
     handle_module = __MODULE__
-    message_module = RailwayIpc.Core.EventMessage
 
     RailwayIpc.MessageConsumptionMock
-    |> expect(:process, fn ^payload, ^handle_module, ^exchange, ^queue, ^message_module ->
+    |> expect(:process, fn ^payload, ^handle_module, ^exchange, ^queue ->
       {:ok,
        %RailwayIpc.MessageConsumption{
          inbound_message: %{decoded_message: %Events.AThingWasDone{}},

--- a/test/railway_ipc/events_consumer_test.exs
+++ b/test/railway_ipc/events_consumer_test.exs
@@ -53,7 +53,6 @@ defmodule RailwayIpc.EventsConsumerTest do
     consumer_module = BatchEventsConsumer
     exchange = "experts"
     queue = "are_es_tee"
-    message_module = RailwayIpc.Core.EventMessage
 
     StreamMock
     |> expect(
@@ -74,7 +73,7 @@ defmodule RailwayIpc.EventsConsumerTest do
     {:ok, message} = Events.AThingWasDone.new() |> Payload.encode()
 
     RailwayIpc.MessageConsumptionMock
-    |> expect(:process, fn ^message, ^consumer_module, ^exchange, ^queue, ^message_module ->
+    |> expect(:process, fn ^message, ^consumer_module, ^exchange, ^queue ->
       {:ok,
        %MessageConsumption{
          inbound_message: %{
@@ -92,7 +91,6 @@ defmodule RailwayIpc.EventsConsumerTest do
     consumer_module = BatchEventsConsumer
     exchange = "experts"
     queue = "are_es_tee"
-    message_module = RailwayIpc.Core.EventMessage
 
     StreamMock
     |> expect(
@@ -113,7 +111,7 @@ defmodule RailwayIpc.EventsConsumerTest do
     message = "{\"encoded_message\":\"\",\"type\":\"Events::SomeUnknownThing\"}"
 
     RailwayIpc.MessageConsumptionMock
-    |> expect(:process, fn ^message, ^consumer_module, ^exchange, ^queue, ^message_module ->
+    |> expect(:process, fn ^message, ^consumer_module, ^exchange, ^queue ->
       {:ok,
        %MessageConsumption{
          inbound_message: %{


### PR DESCRIPTION
Since we now only support "event" messages for the time being, there's no need to pass around the `EventMessage` module anymore. This simplifies function arguments, making future refactoring easier.