### PR TITLE
Support for handing JSON protobufs

### DIFF
--- a/lib/railway_ipc/core/event_message.ex
+++ b/lib/railway_ipc/core/event_message.ex
@@ -4,15 +4,13 @@ defmodule RailwayIpc.Core.EventMessage do
 
   alias RailwayIpc.Core.Payload
 
-  def new(%{
-        payload: payload
-      }) do
+  def new(%{payload: payload}, message_format \\ nil) do
     %__MODULE__{encoded_message: payload}
-    |> decode()
+    |> decode(message_format)
   end
 
-  def decode(%{encoded_message: encoded_message} = event_message) do
-    case Payload.decode(encoded_message) do
+  def decode(%{encoded_message: encoded_message} = event_message, message_format) do
+    case Payload.decode(encoded_message, message_format) do
       {:ok, decoded_message} ->
         message = update(event_message, %{decoded_message: decoded_message})
         {:ok, message}

--- a/lib/railway_ipc/core/events_consumer.ex
+++ b/lib/railway_ipc/core/events_consumer.ex
@@ -9,11 +9,11 @@ defmodule RailwayIpc.Core.EventsConsumer do
                          RailwayIpc.MessageConsumption
                        )
 
-  def process(payload, module, exchange, queue, ack_func) do
+  def process(payload, module, exchange, queue, ack_func, message_format \\ nil) do
     Telemetry.track_process_message(
       %{payload: payload, module: module, exchange: exchange, queue: queue},
       fn ->
-        result = @message_consumption.process(payload, module, exchange, queue)
+        result = @message_consumption.process(payload, module, exchange, queue, message_format)
         {result |> post_processing(ack_func), %{result: result}}
       end
     )

--- a/lib/railway_ipc/core/payload.ex
+++ b/lib/railway_ipc/core/payload.ex
@@ -8,9 +8,10 @@ defmodule RailwayIpc.Core.Payload do
   """
 
   alias RailwayIpc.Core.MessageFormat.BinaryProtobuf
+  alias RailwayIpc.Core.MessageFormat.JsonProtobuf
 
-  def decode(payload) do
-    case BinaryProtobuf.decode(payload) do
+  def decode(payload, message_format \\ nil) do
+    case get_formatter(message_format).decode(payload) do
       # FIXME: We should be consistent and return type for the :ok case
       # like we do for the :unknown_message_type case
       {:ok, proto, _type} -> {:ok, proto}
@@ -41,5 +42,13 @@ defmodule RailwayIpc.Core.Payload do
 
     Regex.replace(~r/\AElixir\./, module_name, "")
     |> String.replace(".", "::")
+  end
+
+  defp get_formatter(message_format) do
+    case message_format do
+      "binary_protobuf" -> BinaryProtobuf
+      "json_protobuf" -> JsonProtobuf
+      _ -> BinaryProtobuf
+    end
   end
 end

--- a/lib/railway_ipc/events_consumer.ex
+++ b/lib/railway_ipc/events_consumer.ex
@@ -31,20 +31,27 @@ defmodule RailwayIpc.EventsConsumer do
         {:noreply, state}
       end
 
-      def handle_info(
-            {:basic_deliver, payload, %{delivery_tag: delivery_tag}},
-            %{channel: channel, exchange: exchange, queue: queue} = state
-          ) do
+      def handle_info({:basic_deliver, payload, metadata}, state) do
+        %{delivery_tag: delivery_tag} = metadata
+        %{channel: channel, exchange: exchange, queue: queue} = state
+        format = get_header(metadata, "message_format")
         Logger.metadata(feature: "railway_ipc_consumer")
 
         Telemetry.track_receive_message(
           %{payload: payload, delivery_tag: delivery_tag, exchange: exchange, queue: queue},
           fn ->
+            # FIXME: Why do we pass this ack function around? We always ack,
+            # and even if we want to reject at some point, we don't need to
+            # pass a function around.
+            #
+            # Answer: It's just for tests; will refactor in the future.
             ack_function = fn ->
               @stream_adapter.ack(channel, delivery_tag)
             end
 
-            result = EventsConsumer.process(payload, __MODULE__, exchange, queue, ack_function)
+            result =
+              EventsConsumer.process(payload, __MODULE__, exchange, queue, ack_function, format)
+
             {{:noreply, state}, %{result: result}}
           end
         )
@@ -67,6 +74,15 @@ defmodule RailwayIpc.EventsConsumer do
       end
 
       defoverridable handle_in: 1
+
+      defp get_header(%{headers: :undefined}, name), do: nil
+
+      defp get_header(%{headers: headers}, name) do
+        {_, _, value} = Enum.find(headers, fn x -> {name, _, _} = x end)
+        value
+      end
+
+      defp get_header(_, _), do: nil
     end
   end
 end

--- a/lib/railway_ipc/message_consumption.ex
+++ b/lib/railway_ipc/message_consumption.ex
@@ -22,11 +22,11 @@ defmodule RailwayIpc.MessageConsumption do
     :result
   ]
 
-  def process(payload, handle_module, exchange, queue) do
+  def process(payload, handle_module, exchange, queue, message_format \\ nil) do
     {:ok, result} =
       @repo.transaction(fn ->
         new(payload, handle_module, exchange, queue)
-        |> decode_message()
+        |> decode_message(message_format)
         |> persist_message()
         |> handle_message()
       end)
@@ -49,9 +49,9 @@ defmodule RailwayIpc.MessageConsumption do
      %__MODULE__{payload: payload, handle_module: handle_module, exchange: exchange, queue: queue}}
   end
 
-  def decode_message({:ok, message_consumption}) do
+  def decode_message({:ok, message_consumption}, message_format) do
     Telemetry.track_decode(%{state: message_consumption}, fn ->
-      case do_decode_message(message_consumption) do
+      case do_decode_message(message_consumption, message_format) do
         {:ok, message} ->
           {handle_decode_success(message_consumption, message),
            %{state: message_consumption, message: message}}
@@ -72,8 +72,8 @@ defmodule RailwayIpc.MessageConsumption do
     end)
   end
 
-  def do_decode_message(message_consumption) do
-    EventMessage.new(message_consumption)
+  def do_decode_message(message_consumption, message_format) do
+    EventMessage.new(message_consumption, message_format)
   end
 
   def persist_message({:ok, message_consumption}) do

--- a/lib/railway_ipc/message_consumption_behaviour.ex
+++ b/lib/railway_ipc/message_consumption_behaviour.ex
@@ -1,5 +1,5 @@
 defmodule RailwayIpc.MessageConsumptionBehaviour do
   @moduledoc false
 
-  @callback process(String.t(), String.t(), String.t(), String.t()) :: tuple()
+  @callback process(String.t(), String.t(), String.t(), String.t(), String.t()) :: tuple()
 end

--- a/test/railway_ipc/core/events_consumer_test.exs
+++ b/test/railway_ipc/core/events_consumer_test.exs
@@ -17,7 +17,7 @@ defmodule RailwayIpc.Core.EventsConsumerTest do
     handle_module = __MODULE__
 
     RailwayIpc.MessageConsumptionMock
-    |> expect(:process, fn ^payload, ^handle_module, ^exchange, ^queue ->
+    |> expect(:process, fn ^payload, ^handle_module, ^exchange, ^queue, nil ->
       {:ok,
        %RailwayIpc.MessageConsumption{
          inbound_message: %{decoded_message: %Events.AThingWasDone{}}
@@ -47,7 +47,7 @@ defmodule RailwayIpc.Core.EventsConsumerTest do
     handle_module = __MODULE__
 
     RailwayIpc.MessageConsumptionMock
-    |> expect(:process, fn ^payload, ^handle_module, ^exchange, ^queue ->
+    |> expect(:process, fn ^payload, ^handle_module, ^exchange, ^queue, nil ->
       {:error,
        %RailwayIpc.MessageConsumption{result: %{status: :error, reason: "Message type not found"}}}
     end)
@@ -75,7 +75,7 @@ defmodule RailwayIpc.Core.EventsConsumerTest do
     handle_module = __MODULE__
 
     RailwayIpc.MessageConsumptionMock
-    |> expect(:process, fn ^payload, ^handle_module, ^exchange, ^queue ->
+    |> expect(:process, fn ^payload, ^handle_module, ^exchange, ^queue, nil ->
       {:ok,
        %RailwayIpc.MessageConsumption{
          inbound_message: %{decoded_message: %Events.AThingWasDone{}},

--- a/test/railway_ipc/events_consumer_test.exs
+++ b/test/railway_ipc/events_consumer_test.exs
@@ -73,7 +73,7 @@ defmodule RailwayIpc.EventsConsumerTest do
     {:ok, message} = Events.AThingWasDone.new() |> Payload.encode()
 
     RailwayIpc.MessageConsumptionMock
-    |> expect(:process, fn ^message, ^consumer_module, ^exchange, ^queue ->
+    |> expect(:process, fn ^message, ^consumer_module, ^exchange, ^queue, nil ->
       {:ok,
        %MessageConsumption{
          inbound_message: %{
@@ -111,7 +111,7 @@ defmodule RailwayIpc.EventsConsumerTest do
     message = "{\"encoded_message\":\"\",\"type\":\"Events::SomeUnknownThing\"}"
 
     RailwayIpc.MessageConsumptionMock
-    |> expect(:process, fn ^message, ^consumer_module, ^exchange, ^queue ->
+    |> expect(:process, fn ^message, ^consumer_module, ^exchange, ^queue, nil ->
       {:ok,
        %MessageConsumption{
          inbound_message: %{

--- a/test/support/rabbit_case.ex
+++ b/test/support/rabbit_case.ex
@@ -92,11 +92,10 @@ defmodule Test.Support.RabbitCase do
       Publish a message. Expects message to be already encoded.
 
       """
-      def publish_message(connection, exchange, message, routing_key \\ "") do
-        {:ok, channel} = AMQP.Channel.open(connection)
+      def publish_message(channel, exchange, message, options \\ []) do
+        routing_key = ""
         AMQP.Exchange.fanout(channel, exchange, options())
-        AMQP.Basic.publish(channel, exchange, routing_key, message)
-        AMQP.Channel.close(channel)
+        AMQP.Basic.publish(channel, exchange, routing_key, message, options)
       end
 
       @doc """


### PR DESCRIPTION
Consumers now check the message metadata for a message format type which is used to decode the message. If one cannot be found, it falls back to assuming the message is a Base64 encoded binary protobuf. This allows us to support JSON protobufs without breaking existing message contracts.

This is a bit ugly due to both the way we mock things and the need to pass the message format down through several layers of functions.  Planning on getting rid of the unnecessary mocks and redundant layers in a separate PR.