### PR TITLE
Protobuf message context maps have string keys

### DIFF
--- a/test/railway_ipc/core/message_format/binary_protobuf_test.exs
+++ b/test/railway_ipc/core/message_format/binary_protobuf_test.exs
@@ -30,13 +30,13 @@ defmodule RailwayIpc.Core.MessageFormat.BinaryProtobufTest do
 
   describe "#decode" do
     test "decode a message to a protobuf" do
-      msg = Events.AThingWasDone.new(uuid: "abc123")
+      msg = Events.AThingWasDone.new(uuid: "abc123", context: %{"some" => "value"})
       {:ok, encoded, _type} = BinaryProtobuf.encode(msg)
 
       expected = {
         :ok,
         %Events.AThingWasDone{
-          context: %{},
+          context: %{"some" => "value"},
           correlation_id: "",
           user_uuid: "",
           uuid: "abc123"

--- a/test/railway_ipc/core/message_format/json_protobuf_test.exs
+++ b/test/railway_ipc/core/message_format/json_protobuf_test.exs
@@ -32,13 +32,13 @@ defmodule RailwayIpc.Core.MessageFormat.JsonProtobufTest do
 
   describe "#decode" do
     test "decode a message to a protobuf" do
-      msg = Events.AThingWasDone.new(uuid: "abc123")
+      msg = Events.AThingWasDone.new(uuid: "abc123", context: %{"some" => "value"})
       {:ok, encoded, _type} = JsonProtobuf.encode(msg)
 
       expected = {
         :ok,
         %Events.AThingWasDone{
-          context: %{},
+          context: %{"some" => "value"},
           correlation_id: "",
           user_uuid: "",
           uuid: "abc123"


### PR DESCRIPTION
Our Protobuf definitions define the context key like this:

```
map<string, string> context = <number>;
```

This presents an issue when decoding JSON protobufs, since the message is essentially a map with atom keys. When we decode a JSON protobuf we get back something like this:

```
%{
  context: %{cohort_uuid: "9583f9c2-b484-44c7-8d6a-91ec3a1e85e9"},
  correlation_id: "97ca5e16-bbf6-4fd8-9541-3a4f54b12f7e",
  data: %LearnIpc.Events.BatchCreated.Data{
    batch_iteration: "ONL02-SENG-FT-081820",
    batch_url: "https://ironboard.lrn.sh/batches/2239",
    batch_uuid: "6fe97e59-8478-4d32-a176-5d3aaab09091",
    organization_uuid: "f0a7aae1-9fab-4a96-a0f7-00517feadd43"
  },
  user_uuid: "3ffd52f5-0339-4bcf-9e8f-51025bf8990d",
  uuid: "611158a2-5c5b-4687-ad53-bd9a3be4e235"
}
```

Notice the context key "cohort_uuid" is an atom. We need to explicitly switch the context's keys to be strings since some applications (like Course Conductor) pattern match on the context. By stringify-ing the context's keys we'll get back something like this (which is what we want):

```
%{
  context: %{"cohort_uuid" => "9583f9c2-b484-44c7-8d6a-91ec3a1e85e9"},
  correlation_id: "97ca5e16-bbf6-4fd8-9541-3a4f54b12f7e",
  data: %LearnIpc.Events.BatchCreated.Data{
    batch_iteration: "ONL02-SENG-FT-081820",
    batch_url: "https://ironboard.lrn.sh/batches/2239",
    batch_uuid: "6fe97e59-8478-4d32-a176-5d3aaab09091",
    organization_uuid: "f0a7aae1-9fab-4a96-a0f7-00517feadd43"
  },
  user_uuid: "3ffd52f5-0339-4bcf-9e8f-51025bf8990d",
  uuid: "611158a2-5c5b-4687-ad53-bd9a3be4e235"
}
```

Notice the context key "cohort_uuid" is now a string.

I also adjusted the tests to document the behavior we want for contexts.

Larger picture, (I believe) the reason why we use string keys for contexts is because the Protobuf "language" doesn't support arbitrary maps with non-string keys.