### PR TITLE
JSON protobuf encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
+* Support for publishing messages in JSON protobuf format. The `#publish` macro now takes an optional second argument which indicates the message format to use. The value can be either `"json_protobuf"` or `"binary_protobuf"`. If the argument is omitted, `"binary_protobuf"` is used.
+
 ### Changed
 * Use own our copy of protobuf library. The master branch of the protobuf library we use has the code for handling JSON protobufs properly. However, there has not been an official release. We've opted to fork the official repo, tag it, and point Railway to use our tagged version. Once the protobuf library publishes an official release, we'll switch back to using it.
 

--- a/lib/railway_ipc/core/payload.ex
+++ b/lib/railway_ipc/core/payload.ex
@@ -14,8 +14,8 @@ defmodule RailwayIpc.Core.Payload do
     get_formatter(message_format).decode(payload)
   end
 
-  def encode(protobuf_struct) do
-    BinaryProtobuf.encode(protobuf_struct)
+  def encode(protobuf_struct, message_format \\ nil) do
+    get_formatter(message_format).encode(protobuf_struct)
   end
 
   defp get_formatter(message_format) do

--- a/lib/railway_ipc/core/published_message.ex
+++ b/lib/railway_ipc/core/published_message.ex
@@ -3,8 +3,8 @@ defmodule RailwayIpc.Core.PublishedMessage do
   defstruct ~w[encoded_message decoded_message type]a
   alias alias RailwayIpc.Core.Payload
 
-  def new(protobuf) do
-    {:ok, encoded_message, type} = protobuf |> Payload.encode()
+  def new(protobuf, format) do
+    {:ok, encoded_message, type} = Payload.encode(protobuf, format)
 
     %__MODULE__{
       decoded_message: protobuf,

--- a/lib/railway_ipc/message_publihsing_behaviour.ex
+++ b/lib/railway_ipc/message_publihsing_behaviour.ex
@@ -1,4 +1,4 @@
 defmodule RailwayIpc.MessagePublishingBehaviour do
   @moduledoc false
-  @callback process(message :: Map.t(), routing_info :: Map.t()) :: tuple()
+  @callback process(message :: Map.t(), routing_info :: Map.t(), format :: String.t()) :: tuple()
 end

--- a/lib/railway_ipc/message_publishing.ex
+++ b/lib/railway_ipc/message_publishing.ex
@@ -12,13 +12,13 @@ defmodule RailwayIpc.MessagePublishing do
     :error
   ]
 
-  def new(protobuf, %RoutingInfo{exchange: exchange, queue: queue}) do
-    outbound_message = PublishedMessage.new(protobuf)
+  def new(protobuf, %RoutingInfo{exchange: exchange, queue: queue}, format) do
+    outbound_message = PublishedMessage.new(protobuf, format)
     %__MODULE__{outbound_message: outbound_message, exchange: exchange, queue: queue}
   end
 
-  def process(protobuf, routing_info) do
-    new(protobuf, routing_info)
+  def process(protobuf, routing_info, format) do
+    new(protobuf, routing_info, format)
     |> persist_message()
   end
 

--- a/lib/railway_ipc/rabbit_mq/rabbit_mq_adapter.ex
+++ b/lib/railway_ipc/rabbit_mq/rabbit_mq_adapter.ex
@@ -109,12 +109,17 @@ defmodule RailwayIpc.RabbitMQ.RabbitMQAdapter do
     )
   end
 
-  def publish(channel, exchange, payload) do
+  def publish(channel, exchange, payload, format) do
     Telemetry.track_rabbit_publish(
       %{channel: channel, exchange: exchange, payload: payload},
       fn ->
         maybe_create_exchange(channel, exchange)
-        result = Basic.publish(channel, exchange, "", payload)
+
+        result =
+          Basic.publish(channel, exchange, "", payload,
+            headers: [{:message_format, :longstr, format}]
+          )
+
         {result, %{}}
       end
     )

--- a/lib/railway_ipc/stream_behaviour.ex
+++ b/lib/railway_ipc/stream_behaviour.ex
@@ -18,7 +18,12 @@ defmodule RailwayIpc.StreamBehaviour do
   @callback get_channel(connection :: map()) :: {:ok, channel :: map()} | {:error, any()}
   @callback ack(channel :: map(), deliver_tag :: binary()) :: any()
   @callback direct_publish(channel :: map(), queue :: binary(), message :: map()) :: any()
-  @callback publish(channel :: map(), exchange :: binary(), message :: map()) :: any()
+  @callback publish(
+              channel :: map(),
+              exchange :: binary(),
+              message :: map(),
+              format :: String.t()
+            ) :: any()
   @callback create_queue(channel :: map(), queue_name :: String.t(), opts :: list()) ::
               {:ok, map()}
   @callback subscribe(channel :: map(), queue :: String.t()) :: any()

--- a/test/e2e/publisher_test.exs
+++ b/test/e2e/publisher_test.exs
@@ -56,7 +56,7 @@ defmodule E2E.PublisherTest do
     # do that, haven't decided
     channel = Connection.publisher_channel(context.pid)
     proto = Proto.new(uuid: UUID.uuid4())
-    :ok = RailwayIpc.Publisher.publish(channel, "railway:test", proto)
+    :ok = RailwayIpc.Publisher.publish(channel, "railway:test", proto, "json_protobuf")
 
     # Make sure it arrived in the queue
     Helpers.wait_for_true(@timeout, fn ->

--- a/test/railway_ipc/core/message_format/binary_protobuf_test.exs
+++ b/test/railway_ipc/core/message_format/binary_protobuf_test.exs
@@ -47,6 +47,24 @@ defmodule RailwayIpc.Core.MessageFormat.BinaryProtobufTest do
       assert expected == BinaryProtobuf.decode(encoded)
     end
 
+    test "properly decodes message with whitespace" do
+      msg = "{\"encoded_message\":\"GgYxMjMxMjM=\",\"type\":\"Events::AThingWasDone\"}\n"
+
+      expected = {
+        :ok,
+        %Events.AThingWasDone{
+          context: %{},
+          correlation_id: "",
+          data: nil,
+          user_uuid: "",
+          uuid: "123123"
+        },
+        "Events::AThingWasDone"
+      }
+
+      assert expected == BinaryProtobuf.decode(msg)
+    end
+
     test "message must be a string" do
       {:error, error} = BinaryProtobuf.decode(:foo)
       assert "Malformed JSON given. Must be a string. (:foo)" == error

--- a/test/railway_ipc/message_publishing_test.exs
+++ b/test/railway_ipc/message_publishing_test.exs
@@ -9,7 +9,7 @@ defmodule RailwayIpc.MessagePublishingTest do
   alias RailwayIpc.Persistence.PublishedMessage
   setup :verify_on_exit!
 
-  describe "process/2" do
+  describe "process" do
     test "it returns an error tuple when persistence fails" do
       message = Events.AThingWasDone.new(%{user_uuid: Ecto.UUID.generate()})
       exchange = "exchange"
@@ -29,7 +29,11 @@ defmodule RailwayIpc.MessagePublishingTest do
       end)
 
       {:error, %{error: ^changeset}} =
-        MessagePublishing.process(message, %RoutingInfo{exchange: exchange})
+        MessagePublishing.process(
+          message,
+          %RoutingInfo{exchange: exchange},
+          "json_protobuf"
+        )
     end
 
     test "it returns an ok tuple when persistence succeeds" do
@@ -47,7 +51,11 @@ defmodule RailwayIpc.MessagePublishingTest do
       end)
 
       {:ok, %{persisted_message: ^published_message_record}} =
-        MessagePublishing.process(message, %RoutingInfo{exchange: exchange})
+        MessagePublishing.process(
+          message,
+          %RoutingInfo{exchange: exchange},
+          "json_protobuf"
+        )
     end
   end
 end

--- a/test/railway_ipc/persistence/published_message_adapter_test.exs
+++ b/test/railway_ipc/persistence/published_message_adapter_test.exs
@@ -10,7 +10,9 @@ defmodule RailwayIpc.Persistence.PublishedMessageAdapterTest do
       correlation_id = Ecto.UUID.generate()
       exchange = "events:a_thing"
       message = Events.AThingWasDone.new(%{user_uuid: user_uuid, correlation_id: correlation_id})
-      message_publishing = MessagePublishing.new(message, %RoutingInfo{exchange: exchange})
+
+      message_publishing =
+        MessagePublishing.new(message, %RoutingInfo{exchange: exchange}, "json_protobuf")
 
       {:ok,
        %{

--- a/test/railway_ipc/persistence_test.exs
+++ b/test/railway_ipc/persistence_test.exs
@@ -10,7 +10,10 @@ defmodule RailwayIpc.PersistenceTest do
     test "inserts the message record" do
       event = Events.AThingWasDone.new(%{uuid: Ecto.UUID.generate()})
       exchange = "ipc:batch:events"
-      message_publishing = MessagePublishing.new(event, %RoutingInfo{exchange: exchange})
+
+      message_publishing =
+        MessagePublishing.new(event, %RoutingInfo{exchange: exchange}, "json_protobuf")
+
       assert {:ok, message} = Persistence.insert_published_message(message_publishing)
       assert message.exchange == exchange
       assert message.uuid != nil
@@ -21,7 +24,10 @@ defmodule RailwayIpc.PersistenceTest do
     test "it inserts a message with a nil exchange" do
       event = Events.AThingWasDone.new(%{uuid: Ecto.UUID.generate()})
       queue = "queue"
-      message_publishing = MessagePublishing.new(event, %RoutingInfo{queue: queue})
+
+      message_publishing =
+        MessagePublishing.new(event, %RoutingInfo{queue: queue}, "json_protobuf")
+
       assert {:ok, message} = Persistence.insert_published_message(message_publishing)
     end
   end

--- a/test/railway_ipc/published_message_test.exs
+++ b/test/railway_ipc/published_message_test.exs
@@ -30,7 +30,7 @@ defmodule RailwayIpc.PublishedMessageTest do
         correlation_id: existing_message.correlation_id
       }
 
-      message_publishing = MessagePublishing.new(protobuf_message, routing_info)
+      message_publishing = MessagePublishing.new(protobuf_message, routing_info, "json_protobuf")
       {:ok, persisted_message} = RailwayIpc.PublishedMessage.create(message_publishing)
 
       assert persisted_message.uuid == existing_message.uuid
@@ -44,7 +44,7 @@ defmodule RailwayIpc.PublishedMessageTest do
         correlation_id: Ecto.UUID.generate()
       }
 
-      message_publishing = MessagePublishing.new(protobuf_message, routing_info)
+      message_publishing = MessagePublishing.new(protobuf_message, routing_info, "json_protobuf")
 
       {:ok, persisted_message} = RailwayIpc.PublishedMessage.create(message_publishing)
 

--- a/test/railway_ipc/rabbit_mq/rabbit_mq_adapter_test.exs
+++ b/test/railway_ipc/rabbit_mq/rabbit_mq_adapter_test.exs
@@ -18,7 +18,7 @@ defmodule RailwayIpc.RabbitMQAdapterTest do
     {:ok, connection} = Rabbit.connect()
     {:ok, channel} = Rabbit.get_channel(connection)
     :ok = AMQP.Exchange.delete(channel, exchange_name)
-    :ok = Rabbit.publish(channel, exchange_name, %{})
+    :ok = Rabbit.publish(channel, exchange_name, %{}, "json_protobuf")
     assert has_exchange?(exchange_name)
   end
 


### PR DESCRIPTION
Support for publishing messages in JSON protobuf format. The `#publish` macro now takes an optional second argument which indicates the message format to use. The value can be either `"json_protobuf"` or `"binary_protobuf"`. If the argument is omitted, `"binary_protobuf"` is used. The message format argument is then passed down through the call chain to the `Payload` module.

There were some redundant tests between `Payload` and `MessageFormat.BinaryProtobuf` that were removed from the `Payload` test module. Added new tests for the `Payload` module to cover the various formats. Updated remaining tests to pass the message format through the call chain.