### PR TITLE
Refactor `ensure_uuid`

### DIFF
--- a/lib/railway_ipc/core/payload.ex
+++ b/lib/railway_ipc/core/payload.ex
@@ -1,22 +1,49 @@
 defmodule RailwayIpc.Core.Payload do
   @moduledoc """
-  _This is an internal module, not part of the public API._
-
   Handles encoding/decoding of messages by delegating to specific message
   format helper modules.
+
+  _This is an internal module, not part of the public API._
 
   """
 
   alias RailwayIpc.Core.MessageFormat.BinaryProtobuf
   alias RailwayIpc.Core.MessageFormat.JsonProtobuf
 
+  @doc """
+  Takes a `payload` and decodes it using the specified `message_format`. If
+  a message format is not provided, the default format (`BinaryProtobuf`)
+  is used.
+
+  """
   def decode(payload, message_format \\ nil) do
     get_formatter(message_format).decode(payload)
   end
 
-  def encode(protobuf_struct, message_format \\ nil) do
-    get_formatter(message_format).encode(protobuf_struct)
+  @doc """
+  Takes a `protobuf` and prepares it for publishing by encoding it in the
+  given `message_format`. If a message format is not provided, the default
+  format (`BinaryProtobuf`) is used.
+
+  Encoded messages require that a protobuf has a UUID. If the given protobuf
+  does not provide a UUID, one will be generated. We currently use `Ecto.UUID`
+  to generate the protobuf UUID. We are investigating using `UUID.uuid4`
+  instead so that we're not coupled to Ecto at this level.
+
+  """
+  def encode(protobuf, message_format \\ nil) do
+    protobuf
+    |> ensure_uuid()
+    |> get_formatter(message_format).encode()
   end
+
+  defp ensure_uuid(%{uuid: uuid} = message) when is_nil(uuid) or "" == uuid do
+    # TODO: Do we really want to couple this to Ecto? Would UUID.uuid4() be
+    # more appropriate?
+    Map.put(message, :uuid, Ecto.UUID.generate())
+  end
+
+  defp ensure_uuid(message), do: message
 
   defp get_formatter(message_format) do
     case message_format do

--- a/test/railway_ipc/core/payload_test.exs
+++ b/test/railway_ipc/core/payload_test.exs
@@ -41,6 +41,13 @@ defmodule RailwayIpc.Core.PayloadTest do
 
       assert expected == Payload.encode(proto)
     end
+
+    test "adds a UUID if one isn't given" do
+      {:ok, encoded, _type} = Events.AThingWasDone.new() |> Payload.encode()
+      {:ok, decoded, _type} = Payload.decode(encoded)
+      assert decoded.uuid != ""
+      assert decoded.uuid != nil
+    end
   end
 
   describe "#decode" do


### PR DESCRIPTION
Move the UUID check down into the `Payload#encode` function. Remove direct `ensure_uuid` usages in `Publisher`. Add a test for `Payload#encode` that checks a UUID is generated if one isn't provided.  Note that we don't need to add a test to ensure a given UUID is not overridden since it's covered by other tests. Remove redundant UUID tests from the `Publisher` test file.