### PR TITLE
Remove publisher RPC support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 ### Changed
 ### Removed
+* [BREAKING CHANGE] Remove publisher RPC support.
+
 ### Fixed
 
 ## [0.4.0] - 2021-02-25

--- a/lib/railway_ipc/application.ex
+++ b/lib/railway_ipc/application.ex
@@ -56,10 +56,7 @@ defmodule RailwayIpc.Application do
         [
           [:railway_ipc, :rabbit_publish, :start],
           [:railway_ipc, :rabbit_direct_publish, :start],
-          [:railway_ipc, :publisher_publish, :start],
-          [:railway_ipc, :publisher_direct_publish, :start],
-          [:railway_ipc, :publisher_rpc_publish, :start],
-          [:railway_ipc, :publisher_rpc_response, :stop]
+          [:railway_ipc, :publisher_publish, :start]
         ],
         &PublisherEvents.handle_event/4
       )

--- a/lib/railway_ipc/loggers/publisher_events.ex
+++ b/lib/railway_ipc/loggers/publisher_events.ex
@@ -4,20 +4,6 @@ defmodule RailwayIpc.Loggers.PublisherEvents do
   import RailwayIpc.Utils, only: [protobuf_to_json: 1]
 
   def handle_event(
-        [:railway_ipc, :publisher_direct_publish, :start],
-        _measurement,
-        metadata,
-        _config
-      ) do
-    Logger.info("Directly publishing",
-      channel: inspect(metadata.channel),
-      protobuf: protobuf_to_json(metadata.message),
-      publisher: metadata.publisher,
-      queue: metadata.queue
-    )
-  end
-
-  def handle_event(
         [:railway_ipc, :publisher_publish, :start],
         _measurement,
         metadata,
@@ -50,47 +36,5 @@ defmodule RailwayIpc.Loggers.PublisherEvents do
       queue: metadata.queue,
       payload: metadata.payload
     )
-  end
-
-  def handle_event(
-        [:railway_ipc, :publisher_rpc_publish, :start],
-        _measurement,
-        metadata,
-        _config
-      ) do
-    Logger.info("Publishing RPC Request",
-      protobuf: protobuf_to_json(metadata.message),
-      queue: inspect(metadata.queue),
-      channel: inspect(metadata.channel),
-      timeout: metadata.timeout
-    )
-  end
-
-  def handle_event(
-        [:railway_ipc, :publisher_rpc_response, :stop],
-        _measurement,
-        metadata,
-        _config
-      ) do
-    case metadata do
-      %{error: _error} ->
-        Logger.error("Received RPC Response",
-          protobuf: protobuf_to_json(metadata.message),
-          queue: inspect(metadata.queue),
-          channel: inspect(metadata.channel),
-          timeout: metadata.timeout,
-          error: metadata.error,
-          reason: metadata.reason
-        )
-
-      _ ->
-        Logger.info("Received RPC Response",
-          protobuf: protobuf_to_json(metadata.message),
-          queue: inspect(metadata.queue),
-          channel: inspect(metadata.channel),
-          timeout: metadata.timeout,
-          response_protobuf: protobuf_to_json(metadata.decoded_message)
-        )
-    end
   end
 end

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -70,22 +70,6 @@ defmodule RailwayIpc.Telemetry do
     span(:publisher_publish, meta, func)
   end
 
-  def track_publisher_direct_publish(meta, func) when is_function(func, 0) do
-    span(:publisher_direct_publish, meta, func)
-  end
-
-  def track_rpc_publish(meta, func) when is_function(func, 0) do
-    span(:publisher_rpc_publish, meta, func)
-  end
-
-  def track_rpc_response(meta, func) when is_function(func, 0) do
-    span(:publisher_rpc_response, meta, func)
-  end
-
-  def track_rpc_response(meta, func) when is_function(func, 0) do
-    span(:publisher_rpc_response, meta, func)
-  end
-
   def track_adding_consumer(meta, func) when is_function(func, 0) do
     span(:add_consumer, meta, func)
   end


### PR DESCRIPTION
Remove RPC publishing support and related logging, telemetry, etc. Looks like this feature wasn't tested, so there's no tests to delete.

Closes #55 