### PR TITLE
Fix encoding of arbitrarily nested protobufs

### DIFF
--- a/test/support/ipc/messages/admitted_applicant.pb.ex
+++ b/test/support/ipc/messages/admitted_applicant.pb.ex
@@ -1,0 +1,15 @@
+defmodule LearnIpc.Entities.AdmittedApplicant do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          uuid: String.t(),
+          external_id: String.t(),
+          salesforce_opportunity_id: String.t()
+        }
+  defstruct [:uuid, :external_id, :salesforce_opportunity_id]
+
+  field(:uuid, 1, type: :string)
+  field(:external_id, 2, type: :string)
+  field(:salesforce_opportunity_id, 3, type: :string)
+end

--- a/test/support/ipc/messages/applicant_admitted.pb.ex
+++ b/test/support/ipc/messages/applicant_admitted.pb.ex
@@ -1,0 +1,51 @@
+defmodule LearnIpc.Events.Admission.ApplicantAdmitted.Data do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          applicant: LearnIpc.Entities.AdmittedApplicant.t() | nil
+        }
+  defstruct [:applicant]
+
+  field(:applicant, 1, type: LearnIpc.Entities.AdmittedApplicant)
+end
+
+defmodule LearnIpc.Events.Admission.ApplicantAdmitted.ContextEntry do
+  @moduledoc false
+  use Protobuf, map: true, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          key: String.t(),
+          value: String.t()
+        }
+  defstruct [:key, :value]
+
+  field(:key, 1, type: :string)
+  field(:value, 2, type: :string)
+end
+
+defmodule LearnIpc.Events.Admission.ApplicantAdmitted do
+  @moduledoc false
+  use Protobuf, syntax: :proto3
+
+  @type t :: %__MODULE__{
+          user_uuid: String.t(),
+          correlation_id: String.t(),
+          uuid: String.t(),
+          context: %{String.t() => String.t()},
+          data: LearnIpc.Events.Admission.ApplicantAdmitted.Data.t() | nil
+        }
+  defstruct [:user_uuid, :correlation_id, :uuid, :context, :data]
+
+  field(:user_uuid, 1, type: :string)
+  field(:correlation_id, 2, type: :string)
+  field(:uuid, 3, type: :string)
+
+  field(:context, 4,
+    repeated: true,
+    type: LearnIpc.Events.Admission.ApplicantAdmitted.ContextEntry,
+    map: true
+  )
+
+  field(:data, 5, type: LearnIpc.Events.Admission.ApplicantAdmitted.Data)
+end


### PR DESCRIPTION
I didn't realize we allow arbitrarily nested protobufs. Recursively ensure that each part of a given protobuf struct is converted to a map. Prevents JSON encoder `Protocol.UndefinedError`'s.