### PR TITLE
Introduce `MessageBus` abstraction

### DIFF
--- a/lib/railway_ipc/message_bus.ex
+++ b/lib/railway_ipc/message_bus.ex
@@ -1,0 +1,18 @@
+defmodule RailwayIpc.MessageBus do
+  @moduledoc """
+  Defines message bus behaviour.
+
+  """
+
+  @doc """
+  Open a new message bus connection.
+
+  """
+  @callback connect(uri :: binary) :: {:ok, term}
+
+  @doc """
+  Close the message bus connection.
+
+  """
+  @callback disconnect(connection :: term) :: :ok
+end

--- a/lib/railway_ipc/message_bus/rabbitmq/adapter.ex
+++ b/lib/railway_ipc/message_bus/rabbitmq/adapter.ex
@@ -1,0 +1,63 @@
+defmodule RailwayIpc.MessageBus.RabbitMQ.Adapter do
+  @moduledoc """
+  RabbitMQ implementation of the message bus.
+
+  _This is an internal module, not part of the public API._
+
+  """
+
+  @behaviour RailwayIpc.MessageBus
+
+  use AMQP
+
+  alias RailwayIpc.MessageBus.RabbitMQ.Telemetry
+
+  @doc """
+  Connect to RabbitMQ using the given `uri`. Returns the `connection`. If
+  unable to connect, keep re-trying.
+
+  If `uri` is not provided, attempt to determine the URI by checking the
+  following configuration variables in this order:
+
+  1. `:rabbitmq_connection_url` value in the `:railway_ipc` application config
+  2. `RABBITMQ_CONNECTION_URL` environment variable
+
+  If all of these fallbacks fail, an error is raised.
+
+  """
+  def connect(uri \\ connection_uri()) do
+    case Connection.open(uri) do
+      {:ok, connection} ->
+        Telemetry.emit_connection_open(__MODULE__)
+        {:ok, connection}
+
+      {:error, {kind, reason}} ->
+        Telemetry.emit_connection_fail(__MODULE__, kind, reason)
+        :timer.sleep(5000)
+        connect(uri)
+    end
+  end
+
+  @doc """
+  Disconnect the given `connection` from RabbitMQ.
+
+  """
+  def disconnect(connection) when not is_nil(connection) do
+    if Process.alive?(connection.pid) do
+      Connection.close(connection)
+      Telemetry.emit_connection_closed(__MODULE__)
+    end
+
+    :ok
+  end
+
+  def disconnect(_), do: :ok
+
+  defp connection_uri do
+    Application.get_env(:railway_ipc, :rabbitmq_connection_url) ||
+      System.get_env("RABBITMQ_CONNECTION_URL") ||
+      raise ~S(Must set config value :railway_ipc, ) <>
+              ~S(:rabbitmq_connection_url, or export environment ) <>
+              ~S(variable RABBITMQ_CONNECTION_URL)
+  end
+end

--- a/lib/railway_ipc/message_bus/rabbitmq/logger.ex
+++ b/lib/railway_ipc/message_bus/rabbitmq/logger.ex
@@ -1,0 +1,78 @@
+defmodule RailwayIpc.MessageBus.RabbitMQ.Logger do
+  @moduledoc """
+  Logging handlers for RabbitMQ Telemetry events.
+
+  You may either define your own handlers for
+  `RailwayIpc.MessageBus.RabbitMQ.Telemetry` events, or use this module.
+
+  To use this module, call `attach` in your application's start function.
+
+  For example, in your `application.ex` file:
+
+  ```
+  alias RailwayIpc.MessageBus.RabbitMQ.Logger, as: RabbitLog
+
+  def start(_type, _args) do
+    :ok = RabbitLog.attach()
+
+    # Your application start code
+  end
+  ```
+
+  """
+
+  require Logger
+
+  @handler_id "railway-ipc-log-rabbitmq-events"
+
+  @connection_open [:railway_ipc, :rabbitmq, :connection, :open]
+  @connection_fail [:railway_ipc, :rabbitmq, :connection, :fail_to_open]
+  @connection_closed [:railway_ipc, :rabbitmq, :connection, :closed]
+
+  @doc """
+  List of events this logger handles.
+
+  """
+  def events do
+    [
+      @connection_open,
+      @connection_fail,
+      @connection_closed
+    ]
+  end
+
+  @doc """
+  Attaches this module's logging handlers to Telemetry. If the handlers are
+  already attached, they will be detached and re-attached.
+
+  """
+  def attach do
+    case :telemetry.attach_many(@handler_id, events(), &__MODULE__.handle_event/4, nil) do
+      :ok ->
+        :ok
+
+      {:error, :already_exists} ->
+        :ok = :telemetry.detach(@handler_id)
+        attach()
+    end
+  end
+
+  @doc """
+  Handles a telemetry event.
+
+  """
+  def handle_event(@connection_open, _measurements, metadata, _config) do
+    Logger.info("[#{metadata.module}] Connected to RabbitMQ")
+  end
+
+  def handle_event(@connection_fail, _measurements, metadata, _config) do
+    Logger.error(
+      "[#{metadata.module}] Failed to connect to RabbitMQ " <>
+        "(#{metadata.kind}, #{metadata.reason})"
+    )
+  end
+
+  def handle_event(@connection_closed, _measurements, metadata, _config) do
+    Logger.info("[#{metadata.module}] RabbitMQ connection closed")
+  end
+end

--- a/lib/railway_ipc/message_bus/rabbitmq/telemetry.ex
+++ b/lib/railway_ipc/message_bus/rabbitmq/telemetry.ex
@@ -1,0 +1,54 @@
+defmodule RailwayIpc.MessageBus.RabbitMQ.Telemetry do
+  @moduledoc """
+  [Telemetry][1] events for RabbitMQ.
+
+  _This is an internal module, not part of the public API._
+
+  [1]: https://github.com/beam-telemetry/telemetry
+
+  """
+
+  alias RailwayIpc.Telemetry
+
+  @doc """
+  Dispatched by `RailwayIpc.MessageBus.RabbitMQ.Adapter` when RabbitMQ
+  connection is opened.
+
+  - Measurement: `%{system_time: integer}`
+  - Metadata: `%{module: term}`
+
+  """
+  def emit_connection_open(module) do
+    event = [:railway_ipc, :rabbitmq, :connection, :open]
+    metadata = %{module: module}
+    Telemetry.emit(event, metadata)
+  end
+
+  @doc """
+  Dispatched by `RailwayIpc.MessageBus.RabbitMQ.Adapter` when RabbitMQ
+  connection cannot be established.
+
+  - Measurement: `%{system_time: integer}`
+  - Metadata: `%{module: term, kind: atom, reason: term}`
+
+  """
+  def emit_connection_fail(module, kind, reason) do
+    event = [:railway_ipc, :rabbitmq, :connection, :fail_to_open]
+    metadata = %{module: module, kind: kind, reason: reason}
+    Telemetry.emit(event, metadata)
+  end
+
+  @doc """
+  Dispatched by `RailwayIpc.MessageBus.RabbitMQ.Adapter` when RabbitMQ
+  connection is closed.
+
+  - Measurement: `%{system_time: integer}`
+  - Metadata: `%{module: term}`
+
+  """
+  def emit_connection_closed(module) do
+    event = [:railway_ipc, :rabbitmq, :connection, :closed]
+    metadata = %{module: module}
+    Telemetry.emit(event, metadata)
+  end
+end

--- a/lib/telemetry.ex
+++ b/lib/telemetry.ex
@@ -106,4 +106,18 @@ defmodule RailwayIpc.Telemetry do
       nil
     )
   end
+
+  @doc """
+  Emit telemetry information. Automatically adds additional measurement
+  information common to all requests (such as system time).
+
+  """
+  def emit(event, metadata) do
+    emit(event, %{}, metadata)
+  end
+
+  def emit(event, measurements, metadata) do
+    additional = %{system_time: System.system_time()}
+    :telemetry.execute(event, Map.merge(measurements, additional), metadata)
+  end
 end

--- a/test/railway_ipc/message_bus/rabbitmq/adapter_test.exs
+++ b/test/railway_ipc/message_bus/rabbitmq/adapter_test.exs
@@ -1,0 +1,58 @@
+defmodule RailwayIpc.MessageBus.RabbitMQ.AdapterTest do
+  use ExUnit.Case
+
+  alias RailwayIpc.MessageBus.RabbitMQ.Adapter
+  alias RailwayIpc.MessageBus.RabbitMQ.Logger, as: RabbitLog
+
+  setup :attach_telemetry_handlers
+
+  test "connect to RabbitMQ" do
+    assert {:ok, %AMQP.Connection{pid: pid}} = Adapter.connect()
+    assert Process.alive?(pid)
+
+    assert_receive {
+      :telemetry_event,
+      [:railway_ipc, :rabbitmq, :connection, :open],
+      %{system_time: _},
+      %{module: _}
+    }
+  end
+
+  test "disconnect from RabbitMQ" do
+    {:ok, pid} = Adapter.connect()
+
+    assert :ok = Adapter.disconnect(pid)
+
+    assert_receive {
+      :telemetry_event,
+      [:railway_ipc, :rabbitmq, :connection, :closed],
+      %{system_time: _},
+      %{module: _}
+    }
+  end
+
+  test "disconnect when connection is nil" do
+    assert :ok = Adapter.disconnect(nil)
+  end
+
+  test "disconnect when connection is already closed" do
+    {:ok, pid} = Adapter.connect()
+
+    assert :ok = Adapter.disconnect(pid)
+    assert :ok = Adapter.disconnect(pid)
+  end
+
+  defp attach_telemetry_handlers(%{test: test}) do
+    self = self()
+
+    :ok =
+      :telemetry.attach_many(
+        "#{test}",
+        RabbitLog.events(),
+        fn name, measurements, metadata, _config ->
+          send(self, {:telemetry_event, name, measurements, metadata})
+        end,
+        nil
+      )
+  end
+end


### PR DESCRIPTION
Lay the groundwork to eventually replace the overly broad interface of `StreamBehaviour` and its related modules. This is all "dark code", nothing is using this new `MessageBus` yet. Rather than making one giant refactoring commit I'm breaking this up into smaller chunks to make reviewing easier.