### PR TITLE
Storage abstraction

### DIFF
--- a/lib/railway_ipc/storage.ex
+++ b/lib/railway_ipc/storage.ex
@@ -1,0 +1,37 @@
+defmodule RailwayIpc.Storage do
+  @moduledoc """
+  Behaviour specification for message persistence.
+
+  Any message persistence adapters must conform to this behaviour. Railway
+  ships with a Ecto adapter, but you may define your own. For example, you
+  may define your own no-op implementation if you do not wish to persist
+  messages. You can then override the Railway configuration to use your
+  custom adapter.
+
+  ```
+  config :railway_ipc,
+    storage: MyCustomAdapter
+  ```
+
+  Note that this behaviour is incomplete, it only handles outgoing (published)
+  messages. This is part of an ongoing refactoring to clean up the internal
+  API of Railway. Support for incoming (consumed) messages will be added at a
+  later date.
+
+  """
+
+  defmodule OutgoingMessage do
+    @moduledoc """
+    Represents an outgoing message and its metadata.
+
+    """
+    defstruct [:protobuf, :encoded, :exchange, :type]
+  end
+
+  @doc """
+  Inserts an outgoing message into the message store.
+
+  """
+  @callback insert(message :: %__MODULE__.OutgoingMessage{}) ::
+              {:ok, term} | {:error, term}
+end

--- a/lib/railway_ipc/storage/db/adapter.ex
+++ b/lib/railway_ipc/storage/db/adapter.ex
@@ -1,0 +1,56 @@
+defmodule RailwayIpc.Storage.DB.Adapter do
+  @moduledoc """
+  Deals with peristing messages to the database. Implements the
+  `RailwayIpc.Storage` behaviour.
+
+  This is an internal module, not part of the public API.
+
+  """
+
+  alias RailwayIpc.Storage.DB.Errors
+  alias RailwayIpc.Storage.DB.PublishedMessage
+  alias RailwayIpc.Storage.OutgoingMessage
+
+  @behaviour RailwayIpc.Storage
+
+  @doc """
+  Insert a `RailwayIpc.Storage.OutgoingMessage` into the published messages
+  table.
+
+  If the message UUID already exists, do nothing. Returns the given
+  `OutgoingMessage`.
+
+  """
+  def insert(%OutgoingMessage{} = msg) do
+    params = message_to_params(msg, "sent")
+
+    case do_insert(params) do
+      {:ok, _changeset} -> {:ok, msg}
+      {:error, changeset} -> {:error, Errors.format(changeset)}
+    end
+  end
+
+  defp do_insert(params) do
+    %PublishedMessage{}
+    |> PublishedMessage.changeset(params)
+    |> repo().insert(on_conflict: :nothing)
+  end
+
+  defp message_to_params(msg, status) do
+    %{protobuf: protobuf, encoded: encoded, exchange: exchange, type: type} = msg
+
+    %{
+      correlation_id: protobuf.correlation_id,
+      encoded_message: encoded,
+      exchange: exchange,
+      message_type: type,
+      status: status,
+      user_uuid: protobuf.user_uuid,
+      uuid: protobuf.uuid
+    }
+  end
+
+  defp repo do
+    Application.fetch_env!(:railway_ipc, :repo)
+  end
+end

--- a/lib/railway_ipc/storage/db/errors.ex
+++ b/lib/railway_ipc/storage/db/errors.ex
@@ -1,0 +1,69 @@
+defmodule RailwayIpc.Storage.DB.Errors do
+  @moduledoc """
+  Helpers for formatting Ecto changeset errors.
+
+  This code was (mostly) lifted from a blog post named
+  [Prettify Ecto Error][1].
+
+  This is an internal module, not part of the public API.
+
+  [1]: https://thebrainfiles.wearebrain.com/prettify-ecto-errors-b85e9a7977f6
+
+  """
+
+  @doc """
+  Formats Ecto changeset errors by converting them from keyword lists into a
+  single string.
+
+  For example, it will convert changeset errors like this:
+
+  ```
+  [
+    encoded_message: {"can't be blank", [validation: :required]},
+    message_type: {"can't be blank", [validation: :required]}
+  ]
+  ```
+
+  Into a single string like this:
+
+  ```
+  "Encoded message can't be blank, Message type can't be blank"
+  ```
+
+  """
+  def format(changeset) do
+    Enum.join(pretty_errors(changeset.errors), ", ")
+  end
+
+  defp pretty_errors(errors) do
+    errors
+    |> Enum.map(&do_prettify/1)
+  end
+
+  defp do_prettify({field_name, message}) when is_bitstring(message) do
+    human_field_name =
+      field_name
+      |> Atom.to_string()
+      |> String.replace("_", " ")
+      |> String.capitalize()
+
+    human_field_name <> " " <> message
+  end
+
+  defp do_prettify({field_name, {message, variables}}) do
+    compound_message = do_interpolate(message, variables)
+    do_prettify({field_name, compound_message})
+  end
+
+  defp do_interpolate(string, [{name, value} | rest]) do
+    n = Atom.to_string(name)
+    msg = String.replace(string, "%{#{n}}", do_to_string(value))
+    do_interpolate(msg, rest)
+  end
+
+  defp do_interpolate(string, []), do: string
+
+  defp do_to_string(value) when is_integer(value), do: Integer.to_string(value)
+  defp do_to_string(value) when is_bitstring(value), do: value
+  defp do_to_string(value) when is_atom(value), do: Atom.to_string(value)
+end

--- a/lib/railway_ipc/storage/db/published_message.ex
+++ b/lib/railway_ipc/storage/db/published_message.ex
@@ -1,0 +1,48 @@
+defmodule RailwayIpc.Storage.DB.PublishedMessage do
+  @moduledoc """
+  Schema and helpers for a published message.
+
+  This is an internal module, not part of the public API.
+
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:uuid, :binary_id, autogenerate: false}
+
+  schema "railway_ipc_published_messages" do
+    field(:correlation_id, :binary_id)
+    field(:encoded_message, :string)
+    field(:exchange, :string)
+    field(:message_type, :string)
+
+    # Published messages don't know anything about queues, not sure why this is
+    # here. Keeping for backwards compatability.
+    field(:queue, :string)
+
+    field(:status, :string)
+    field(:user_uuid, :binary_id)
+    timestamps()
+  end
+
+  @doc false
+  def changeset(message, attrs) do
+    message
+    |> cast(attrs, permitted_fields())
+    |> validate_required([:uuid, :encoded_message, :message_type, :status])
+  end
+
+  defp permitted_fields do
+    [
+      :correlation_id,
+      :encoded_message,
+      :exchange,
+      :message_type,
+      :queue,
+      :status,
+      :user_uuid,
+      :uuid
+    ]
+  end
+end

--- a/test/railway_ipc/storage/db/adapter_test.exs
+++ b/test/railway_ipc/storage/db/adapter_test.exs
@@ -1,0 +1,45 @@
+defmodule RailwayIpc.Storage.DB.AdapterTest do
+  use RailwayIpc.DataCase, async: true
+
+  alias Events.AThingWasDone, as: Proto
+  alias RailwayIpc.Core.MessageFormat.BinaryProtobuf
+  alias RailwayIpc.Storage.DB.Adapter
+  alias RailwayIpc.Storage.OutgoingMessage
+
+  describe "#insert" do
+    setup do
+      proto = Proto.new(uuid: UUID.uuid4())
+      {:ok, encoded, type} = BinaryProtobuf.encode(proto)
+
+      args = %OutgoingMessage{
+        protobuf: proto,
+        type: type,
+        exchange: "lightrail:test",
+        encoded: encoded
+      }
+
+      %{valid_args: args}
+    end
+
+    test "valid message is persisted", %{valid_args: args} do
+      {:ok, msg} = Adapter.insert(args)
+      persisted = get_published_message!(msg.protobuf.uuid)
+      assert args.encoded == persisted.encoded_message
+      assert "lightrail:test" == persisted.exchange
+      assert args.type == persisted.message_type
+      assert "sent" == persisted.status
+    end
+
+    test "changeset errors are prettified", %{valid_args: args} do
+      invalid_args = %{args | type: nil, encoded: nil}
+      {:error, msg} = Adapter.insert(invalid_args)
+      assert "Encoded message can't be blank, Message type can't be blank" == msg
+    end
+
+    test "doesn't insert the same message twice", %{valid_args: args} do
+      {:ok, _msg} = Adapter.insert(args)
+      {:ok, msg} = Adapter.insert(args)
+      assert msg == args
+    end
+  end
+end

--- a/test/railway_ipc/storage/db/published_message_test.exs
+++ b/test/railway_ipc/storage/db/published_message_test.exs
@@ -1,0 +1,78 @@
+defmodule RailwayIpc.Storage.DB.PublishedMessageTest do
+  use ExUnit.Case, async: true
+
+  alias RailwayIpc.Storage.DB.PublishedMessage
+
+  setup do
+    uuid = "deadbeef-dead-dead-dead-deaddeafbeef"
+
+    attrs = %{
+      correlation_id: uuid,
+      encoded_message: "xyz-gibberish-xyz",
+      exchange: "lightrail:test",
+      message_type: "TestMessage",
+      status: "sent",
+      user_uuid: uuid,
+      uuid: uuid
+    }
+
+    %{uuid: uuid, valid_attrs: attrs}
+  end
+
+  describe "#changeset" do
+    test "permitted fields", %{uuid: uuid, valid_attrs: valid_attrs} do
+      changeset = PublishedMessage.changeset(%PublishedMessage{}, valid_attrs)
+      assert changeset.valid?
+      msg = Ecto.Changeset.apply_changes(changeset)
+      assert uuid == msg.correlation_id
+      assert "xyz-gibberish-xyz" == msg.encoded_message
+      assert "lightrail:test" == msg.exchange
+      assert "TestMessage" == msg.message_type
+      assert "sent" == msg.status
+      assert uuid == msg.user_uuid
+      assert uuid == msg.uuid
+    end
+
+    test "unpermitted fields are ignored", %{valid_attrs: valid_attrs} do
+      attrs = Map.put(valid_attrs, :extra, 42)
+      changeset = PublishedMessage.changeset(%PublishedMessage{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "UUID required", %{valid_attrs: valid_attrs} do
+      attrs = Map.delete(valid_attrs, :uuid)
+      changeset = PublishedMessage.changeset(%PublishedMessage{}, attrs)
+      refute changeset.valid?
+
+      assert [uuid: {"can't be blank", [validation: :required]}] ==
+               changeset.errors
+    end
+
+    test "encoded_message is required", %{valid_attrs: valid_attrs} do
+      attrs = Map.delete(valid_attrs, :encoded_message)
+      changeset = PublishedMessage.changeset(%PublishedMessage{}, attrs)
+      refute changeset.valid?
+
+      assert [encoded_message: {"can't be blank", [validation: :required]}] ==
+               changeset.errors
+    end
+
+    test "message_type is required", %{valid_attrs: valid_attrs} do
+      attrs = Map.delete(valid_attrs, :message_type)
+      changeset = PublishedMessage.changeset(%PublishedMessage{}, attrs)
+      refute changeset.valid?
+
+      assert [message_type: {"can't be blank", [validation: :required]}] ==
+               changeset.errors
+    end
+
+    test "status is required", %{valid_attrs: valid_attrs} do
+      attrs = Map.delete(valid_attrs, :status)
+      changeset = PublishedMessage.changeset(%PublishedMessage{}, attrs)
+      refute changeset.valid?
+
+      assert [status: {"can't be blank", [validation: :required]}] ==
+               changeset.errors
+    end
+  end
+end


### PR DESCRIPTION
Rather than trying to refactor persistence code that contains some circular dependencies, add a parallel abstraction named `Storage`. This will eventually replace the existing persistence code. Currently, storage only deals with published messages, since I'm concentrating on the publisher half of the code.

This also refactors `DataCase` a bit, removing some unused code and cleaning up the setup code.

All of this is "dark code", nothing is using it yet.